### PR TITLE
Add SQLAlchemy lifecycle utilities

### DIFF
--- a/examples/sqlalchemy_shop/README.md
+++ b/examples/sqlalchemy_shop/README.md
@@ -46,6 +46,9 @@ The app will:
 - Seed sample data on first run
 - Start the MCP server
 
+The lifecycle is managed using the `sqlalchemy_lifespan` helper from
+`enrichmcp.sqlalchemy`, which provides a session factory to all resources.
+
 ## Current Limitations
 
 This example currently includes manual implementations of:

--- a/examples/sqlalchemy_shop/app.py
+++ b/examples/sqlalchemy_shop/app.py
@@ -13,19 +13,11 @@ from datetime import datetime
 from typing import Optional
 
 from sqlalchemy import ForeignKey, func, select
-<<<<<<< HEAD
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from enrichmcp import CursorResult, EnrichContext, EnrichMCP, PageResult
 from enrichmcp.sqlalchemy import EnrichSQLAlchemyMixin, sqlalchemy_lifespan
-=======
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
-
-from enrichmcp import CursorResult, EnrichContext, EnrichMCP, PageResult
-from enrichmcp.sqlalchemy import EnrichSQLAlchemyMixin
->>>>>>> feature/sqlalchemy-support/simba
 
 
 # Create base class with our mixin
@@ -40,7 +32,6 @@ class User(Base):
     __tablename__ = "users"
 
     id: Mapped[int] = mapped_column(
-<<<<<<< HEAD
         primary_key=True, info={"description": "Unique user identifier"}
     )
     username: Mapped[str] = mapped_column(
@@ -53,28 +44,6 @@ class User(Base):
     )
     created_at: Mapped[datetime] = mapped_column(
         info={"description": "When the user account was created"}
-=======
-        primary_key=True,
-        info={"description": "Unique user identifier"},
-    )
-    username: Mapped[str] = mapped_column(
-        unique=True,
-        info={"description": "User's unique username"},
-    )
-    email: Mapped[str] = mapped_column(
-        unique=True,
-        info={"description": "User's email address"},
-    )
-    full_name: Mapped[str] = mapped_column(
-        info={"description": "User's full name"},
-    )
-    is_active: Mapped[bool] = mapped_column(
-        default=True,
-        info={"description": "Whether the user account is active"},
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        info={"description": "When the user account was created"},
->>>>>>> feature/sqlalchemy-support/simba
     )
 
     # Relationships
@@ -89,7 +58,6 @@ class Product(Base):
     __tablename__ = "products"
 
     id: Mapped[int] = mapped_column(
-<<<<<<< HEAD
         primary_key=True, info={"description": "Unique product identifier"}
     )
     name: Mapped[str] = mapped_column(info={"description": "Product name"})
@@ -102,31 +70,6 @@ class Product(Base):
     )
     category: Mapped[str] = mapped_column(info={"description": "Product category"})
     created_at: Mapped[datetime] = mapped_column(info={"description": "When the product was added"})
-=======
-        primary_key=True,
-        info={"description": "Unique product identifier"},
-    )
-    name: Mapped[str] = mapped_column(
-        info={"description": "Product name"},
-    )
-    description: Mapped[str | None] = mapped_column(
-        nullable=True,
-        info={"description": "Product description"},
-    )
-    price: Mapped[float] = mapped_column(
-        info={"description": "Product price in USD"},
-    )
-    stock_quantity: Mapped[int] = mapped_column(
-        default=0,
-        info={"description": "Current stock level"},
-    )
-    category: Mapped[str] = mapped_column(
-        info={"description": "Product category"},
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        info={"description": "When the product was added"},
-    )
->>>>>>> feature/sqlalchemy-support/simba
 
     # Relationships
     order_items: Mapped[list["OrderItem"]] = relationship(
@@ -140,7 +83,6 @@ class Order(Base):
     __tablename__ = "orders"
 
     id: Mapped[int] = mapped_column(
-<<<<<<< HEAD
         primary_key=True, info={"description": "Unique order identifier"}
     )
     order_number: Mapped[str] = mapped_column(
@@ -156,47 +98,13 @@ class Order(Base):
     created_at: Mapped[datetime] = mapped_column(info={"description": "When the order was placed"})
     updated_at: Mapped[datetime] = mapped_column(
         info={"description": "When the order was last updated"}
-=======
-        primary_key=True,
-        info={"description": "Unique order identifier"},
-    )
-    order_number: Mapped[str] = mapped_column(
-        unique=True,
-        info={"description": "Human-readable order number"},
-    )
-    user_id: Mapped[int] = mapped_column(
-        ForeignKey("users.id"),
-        info={"description": "ID of the user who placed the order"},
-    )
-    status: Mapped[str] = mapped_column(
-        info={"description": "Order status (pending, processing, shipped, delivered, cancelled)"},
-    )
-    total_amount: Mapped[float] = mapped_column(
-        info={"description": "Total order amount in USD"},
-    )
-    created_at: Mapped[datetime] = mapped_column(
-        info={"description": "When the order was placed"},
-    )
-    updated_at: Mapped[datetime] = mapped_column(
-        info={"description": "When the order was last updated"},
->>>>>>> feature/sqlalchemy-support/simba
     )
 
     # Additional fields
     shipping_address: Mapped[str | None] = mapped_column(
-<<<<<<< HEAD
         nullable=True, info={"description": "Shipping address"}
     )
     notes: Mapped[str | None] = mapped_column(nullable=True, info={"description": "Order notes"})
-=======
-        nullable=True,
-        info={"description": "Shipping address"},
-    )
-    notes: Mapped[str | None] = mapped_column(
-        nullable=True,
-        info={"description": "Order notes"},
-    )
->>>>>>> feature/sqlalchemy-support/simba
 
     # Relationships
     user: Mapped[User] = relationship(
@@ -215,7 +123,6 @@ class OrderItem(Base):
     __tablename__ = "order_items"
 
     id: Mapped[int] = mapped_column(
-<<<<<<< HEAD
         primary_key=True, info={"description": "Unique order item identifier"}
     )
     order_id: Mapped[int] = mapped_column(
@@ -230,27 +137,6 @@ class OrderItem(Base):
     )
     total_price: Mapped[float] = mapped_column(
         info={"description": "Total price for this line item"}
-=======
-        primary_key=True,
-        info={"description": "Unique order item identifier"},
-    )
-    order_id: Mapped[int] = mapped_column(
-        ForeignKey("orders.id"),
-        info={"description": "ID of the parent order"},
-    )
-    product_id: Mapped[int] = mapped_column(
-        ForeignKey("products.id"),
-        info={"description": "ID of the product"},
-    )
-    quantity: Mapped[int] = mapped_column(
-        info={"description": "Quantity ordered"},
-    )
-    unit_price: Mapped[float] = mapped_column(
-        info={"description": "Price per unit at time of order"},
-    )
-    total_price: Mapped[float] = mapped_column(
-        info={"description": "Total price for this line item"},
->>>>>>> feature/sqlalchemy-support/simba
     )
 
     # Relationships
@@ -268,31 +154,9 @@ db_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "shop.db")
 engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
 
 
-<<<<<<< HEAD
 # Seed database with sample data
 async def seed_database(session: AsyncSession) -> None:
     """Populate the database with example data."""
-=======
-# Create EnrichMCP app
-@asynccontextmanager
-async def lifespan(app: EnrichMCP):
-    """Initialize database and provide session in context."""
-    # Create tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-
-    # Seed some data if needed
-    async with AsyncSessionMaker() as session:
-        # Check if we have any users
-        result = await session.execute(select(User).limit(1))
-        if not result.scalar():
-            # Add sample data
-            await seed_database(session)
-            await session.commit()
-
-    # Provide session factory in context
-    yield {"session_factory": AsyncSessionMaker}
->>>>>>> feature/sqlalchemy-support/simba
 
     users = [
         User(
@@ -726,126 +590,6 @@ async def get_order_item_product(
         )
 
 
-<<<<<<< HEAD
-=======
-async def seed_database(session: AsyncSession):
-    """Seed the database with sample data."""
-    # Create users
-    users = [
-        User(
-            username="john_doe",
-            email="john@example.com",
-            full_name="John Doe",
-            created_at=datetime.now(),
-        ),
-        User(
-            username="jane_smith",
-            email="jane@example.com",
-            full_name="Jane Smith",
-            created_at=datetime.now(),
-        ),
-    ]
-    session.add_all(users)
-
-    # Create products
-    products = [
-        Product(
-            name="Laptop",
-            description="High-performance laptop",
-            price=999.99,
-            stock_quantity=50,
-            category="Electronics",
-            created_at=datetime.now(),
-        ),
-        Product(
-            name="Wireless Mouse",
-            description="Ergonomic wireless mouse",
-            price=29.99,
-            stock_quantity=200,
-            category="Electronics",
-            created_at=datetime.now(),
-        ),
-        Product(
-            name="USB-C Cable",
-            description="Fast charging USB-C cable",
-            price=19.99,
-            stock_quantity=500,
-            category="Accessories",
-            created_at=datetime.now(),
-        ),
-        Product(
-            name="Coffee Maker",
-            description="Programmable coffee maker",
-            price=79.99,
-            stock_quantity=30,
-            category="Appliances",
-            created_at=datetime.now(),
-        ),
-    ]
-    session.add_all(products)
-
-    # Flush to get IDs
-    await session.flush()
-
-    # Create orders
-    order1 = Order(
-        order_number="ORD-001",
-        user_id=users[0].id,
-        status="delivered",
-        total_amount=1029.98,
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        shipping_address="123 Main St, City, State 12345",
-    )
-
-    order2 = Order(
-        order_number="ORD-002",
-        user_id=users[1].id,
-        status="processing",
-        total_amount=99.98,
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        shipping_address="456 Oak Ave, Town, State 67890",
-    )
-
-    session.add_all([order1, order2])
-    await session.flush()
-
-    # Create order items
-    items = [
-        OrderItem(
-            order_id=order1.id,
-            product_id=products[0].id,  # Laptop
-            quantity=1,
-            unit_price=999.99,
-            total_price=999.99,
-        ),
-        OrderItem(
-            order_id=order1.id,
-            product_id=products[1].id,  # Mouse
-            quantity=1,
-            unit_price=29.99,
-            total_price=29.99,
-        ),
-        OrderItem(
-            order_id=order2.id,
-            product_id=products[3].id,  # Coffee Maker
-            quantity=1,
-            unit_price=79.99,
-            total_price=79.99,
-        ),
-        OrderItem(
-            order_id=order2.id,
-            product_id=products[2].id,  # USB-C Cable
-            quantity=1,
-            unit_price=19.99,
-            total_price=19.99,
-        ),
-    ]
-    session.add_all(items)
-
-
->>>>>>> feature/sqlalchemy-support/simba
 if __name__ == "__main__":
     # Run the app
     app.run()

--- a/examples/sqlalchemy_shop/app.py
+++ b/examples/sqlalchemy_shop/app.py
@@ -8,18 +8,16 @@ Note: The resolvers and auto-generated resources are not yet implemented,
 so this example shows the model setup and basic structure.
 """
 
-import asyncio
 import os
-from contextlib import asynccontextmanager
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
-from sqlalchemy import ForeignKey, String, create_engine, select, func
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy import ForeignKey, func, select
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
-from enrichmcp import EnrichMCP, EnrichContext, PageResult, CursorResult
-from enrichmcp.sqlalchemy import EnrichSQLAlchemyMixin
+from enrichmcp import CursorResult, EnrichContext, EnrichMCP, PageResult
+from enrichmcp.sqlalchemy import EnrichSQLAlchemyMixin, sqlalchemy_lifespan
 
 
 # Create base class with our mixin
@@ -30,88 +28,123 @@ class Base(DeclarativeBase, EnrichSQLAlchemyMixin):
 # Define SQLAlchemy models
 class User(Base):
     """User account in the shop system."""
+
     __tablename__ = "users"
-    
-    id: Mapped[int] = mapped_column(primary_key=True, info={"description": "Unique user identifier"})
-    username: Mapped[str] = mapped_column(unique=True, info={"description": "User's unique username"})
+
+    id: Mapped[int] = mapped_column(
+        primary_key=True, info={"description": "Unique user identifier"}
+    )
+    username: Mapped[str] = mapped_column(
+        unique=True, info={"description": "User's unique username"}
+    )
     email: Mapped[str] = mapped_column(unique=True, info={"description": "User's email address"})
     full_name: Mapped[str] = mapped_column(info={"description": "User's full name"})
-    is_active: Mapped[bool] = mapped_column(default=True, info={"description": "Whether the user account is active"})
-    created_at: Mapped[datetime] = mapped_column(info={"description": "When the user account was created"})
-    
+    is_active: Mapped[bool] = mapped_column(
+        default=True, info={"description": "Whether the user account is active"}
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        info={"description": "When the user account was created"}
+    )
+
     # Relationships
-    orders: Mapped[List["Order"]] = relationship(
-        back_populates="user",
-        info={"description": "All orders placed by this user"}
+    orders: Mapped[list["Order"]] = relationship(
+        back_populates="user", info={"description": "All orders placed by this user"}
     )
 
 
 class Product(Base):
     """Product available in the shop."""
+
     __tablename__ = "products"
-    
-    id: Mapped[int] = mapped_column(primary_key=True, info={"description": "Unique product identifier"})
+
+    id: Mapped[int] = mapped_column(
+        primary_key=True, info={"description": "Unique product identifier"}
+    )
     name: Mapped[str] = mapped_column(info={"description": "Product name"})
-    description: Mapped[Optional[str]] = mapped_column(nullable=True, info={"description": "Product description"})
+    description: Mapped[str | None] = mapped_column(
+        nullable=True, info={"description": "Product description"}
+    )
     price: Mapped[float] = mapped_column(info={"description": "Product price in USD"})
-    stock_quantity: Mapped[int] = mapped_column(default=0, info={"description": "Current stock level"})
+    stock_quantity: Mapped[int] = mapped_column(
+        default=0, info={"description": "Current stock level"}
+    )
     category: Mapped[str] = mapped_column(info={"description": "Product category"})
     created_at: Mapped[datetime] = mapped_column(info={"description": "When the product was added"})
-    
+
     # Relationships
-    order_items: Mapped[List["OrderItem"]] = relationship(
-        back_populates="product",
-        info={"description": "Order items containing this product"}
+    order_items: Mapped[list["OrderItem"]] = relationship(
+        back_populates="product", info={"description": "Order items containing this product"}
     )
 
 
 class Order(Base):
     """Customer order."""
+
     __tablename__ = "orders"
-    
-    id: Mapped[int] = mapped_column(primary_key=True, info={"description": "Unique order identifier"})
-    order_number: Mapped[str] = mapped_column(unique=True, info={"description": "Human-readable order number"})
-    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"), info={"description": "ID of the user who placed the order"})
-    status: Mapped[str] = mapped_column(info={"description": "Order status (pending, processing, shipped, delivered, cancelled)"})
+
+    id: Mapped[int] = mapped_column(
+        primary_key=True, info={"description": "Unique order identifier"}
+    )
+    order_number: Mapped[str] = mapped_column(
+        unique=True, info={"description": "Human-readable order number"}
+    )
+    user_id: Mapped[int] = mapped_column(
+        ForeignKey("users.id"), info={"description": "ID of the user who placed the order"}
+    )
+    status: Mapped[str] = mapped_column(
+        info={"description": "Order status (pending, processing, shipped, delivered, cancelled)"}
+    )
     total_amount: Mapped[float] = mapped_column(info={"description": "Total order amount in USD"})
     created_at: Mapped[datetime] = mapped_column(info={"description": "When the order was placed"})
-    updated_at: Mapped[datetime] = mapped_column(info={"description": "When the order was last updated"})
-    
+    updated_at: Mapped[datetime] = mapped_column(
+        info={"description": "When the order was last updated"}
+    )
+
     # Additional fields
-    shipping_address: Mapped[Optional[str]] = mapped_column(nullable=True, info={"description": "Shipping address"})
-    notes: Mapped[Optional[str]] = mapped_column(nullable=True, info={"description": "Order notes"})
-    
+    shipping_address: Mapped[str | None] = mapped_column(
+        nullable=True, info={"description": "Shipping address"}
+    )
+    notes: Mapped[str | None] = mapped_column(nullable=True, info={"description": "Order notes"})
+
     # Relationships
     user: Mapped[User] = relationship(
-        back_populates="orders",
-        info={"description": "Customer who placed this order"}
+        back_populates="orders", info={"description": "Customer who placed this order"}
     )
-    items: Mapped[List["OrderItem"]] = relationship(
+    items: Mapped[list["OrderItem"]] = relationship(
         back_populates="order",
         cascade="all, delete-orphan",
-        info={"description": "Items in this order"}
+        info={"description": "Items in this order"},
     )
 
 
 class OrderItem(Base):
     """Individual item within an order."""
+
     __tablename__ = "order_items"
-    
-    id: Mapped[int] = mapped_column(primary_key=True, info={"description": "Unique order item identifier"})
-    order_id: Mapped[int] = mapped_column(ForeignKey("orders.id"), info={"description": "ID of the parent order"})
-    product_id: Mapped[int] = mapped_column(ForeignKey("products.id"), info={"description": "ID of the product"})
+
+    id: Mapped[int] = mapped_column(
+        primary_key=True, info={"description": "Unique order item identifier"}
+    )
+    order_id: Mapped[int] = mapped_column(
+        ForeignKey("orders.id"), info={"description": "ID of the parent order"}
+    )
+    product_id: Mapped[int] = mapped_column(
+        ForeignKey("products.id"), info={"description": "ID of the product"}
+    )
     quantity: Mapped[int] = mapped_column(info={"description": "Quantity ordered"})
-    unit_price: Mapped[float] = mapped_column(info={"description": "Price per unit at time of order"})
-    total_price: Mapped[float] = mapped_column(info={"description": "Total price for this line item"})
-    
+    unit_price: Mapped[float] = mapped_column(
+        info={"description": "Price per unit at time of order"}
+    )
+    total_price: Mapped[float] = mapped_column(
+        info={"description": "Total price for this line item"}
+    )
+
     # Relationships
     order: Mapped[Order] = relationship(
-        back_populates="items",
-        info={"description": "Parent order"}
+        back_populates="items", info={"description": "Parent order"}
     )
     product: Mapped[Product] = relationship(
-        back_populates="order_items",
-        info={"description": "Product details"}
+        back_populates="order_items", info={"description": "Product details"}
     )
 
 
@@ -119,34 +152,127 @@ class OrderItem(Base):
 # Use absolute path relative to this file
 db_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "shop.db")
 engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
-AsyncSessionMaker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
 
 
-# Create EnrichMCP app
-@asynccontextmanager
-async def lifespan(app: EnrichMCP):
-    """Initialize database and provide session in context."""
-    # Create tables
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
-    
-    # Seed some data if needed
-    async with AsyncSessionMaker() as session:
-        # Check if we have any users
-        result = await session.execute(select(User).limit(1))
-        if not result.scalar():
-            # Add sample data
-            await seed_database(session)
-            await session.commit()
-    
-    # Provide session factory in context
-    yield {"session_factory": AsyncSessionMaker}
+# Seed database with sample data
+async def seed_database(session: AsyncSession) -> None:
+    """Populate the database with example data."""
 
+    users = [
+        User(
+            username="john_doe",
+            email="john@example.com",
+            full_name="John Doe",
+            created_at=datetime.now(),
+        ),
+        User(
+            username="jane_smith",
+            email="jane@example.com",
+            full_name="Jane Smith",
+            created_at=datetime.now(),
+        ),
+    ]
+    session.add_all(users)
+
+    products = [
+        Product(
+            name="Laptop",
+            description="High-performance laptop",
+            price=999.99,
+            stock_quantity=50,
+            category="Electronics",
+            created_at=datetime.now(),
+        ),
+        Product(
+            name="Wireless Mouse",
+            description="Ergonomic wireless mouse",
+            price=29.99,
+            stock_quantity=200,
+            category="Electronics",
+            created_at=datetime.now(),
+        ),
+        Product(
+            name="USB-C Cable",
+            description="Fast charging USB-C cable",
+            price=19.99,
+            stock_quantity=500,
+            category="Accessories",
+            created_at=datetime.now(),
+        ),
+        Product(
+            name="Coffee Maker",
+            description="Programmable coffee maker",
+            price=79.99,
+            stock_quantity=30,
+            category="Appliances",
+            created_at=datetime.now(),
+        ),
+    ]
+    session.add_all(products)
+    await session.flush()
+
+    order1 = Order(
+        order_number="ORD-001",
+        user_id=users[0].id,
+        status="delivered",
+        total_amount=1029.98,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        shipping_address="123 Main St, City, State 12345",
+    )
+    order2 = Order(
+        order_number="ORD-002",
+        user_id=users[1].id,
+        status="processing",
+        total_amount=99.98,
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        shipping_address="456 Oak Ave, Town, State 67890",
+    )
+    session.add_all([order1, order2])
+    await session.flush()
+
+    items = [
+        OrderItem(
+            order_id=order1.id,
+            product_id=products[0].id,
+            quantity=1,
+            unit_price=999.99,
+            total_price=999.99,
+        ),
+        OrderItem(
+            order_id=order1.id,
+            product_id=products[1].id,
+            quantity=1,
+            unit_price=29.99,
+            total_price=29.99,
+        ),
+        OrderItem(
+            order_id=order2.id,
+            product_id=products[3].id,
+            quantity=1,
+            unit_price=79.99,
+            total_price=79.99,
+        ),
+        OrderItem(
+            order_id=order2.id,
+            product_id=products[2].id,
+            quantity=1,
+            unit_price=19.99,
+            total_price=19.99,
+        ),
+    ]
+    session.add_all(items)
+
+
+# Application instance will be created after defining the lifespan
+
+lifespan = sqlalchemy_lifespan(Base, engine, seed=seed_database)
 
 app = EnrichMCP(
     title="Shop API (SQLAlchemy)",
     description="E-commerce shop API using SQLAlchemy models",
-    lifespan=lifespan
+    lifespan=lifespan,
 )
 
 
@@ -155,36 +281,40 @@ app = EnrichMCP(
 @app.entity
 class UserEnrichModel(User.__enrich_model__()):
     """User entity based on SQLAlchemy model."""
+
     pass
 
 
-@app.entity  
+@app.entity
 class ProductEnrichModel(Product.__enrich_model__()):
     """Product entity based on SQLAlchemy model."""
+
     pass
 
 
 @app.entity
 class OrderEnrichModel(Order.__enrich_model__()):
     """Order entity based on SQLAlchemy model."""
+
     pass
 
 
 @app.entity
 class OrderItemEnrichModel(OrderItem.__enrich_model__()):
     """Order item entity based on SQLAlchemy model."""
+
     pass
 
 
 # Manual resources for now (until auto-generation is implemented)
 @app.resource
-async def list_users(ctx: EnrichContext) -> List[UserEnrichModel]:
+async def list_users(ctx: EnrichContext) -> list[UserEnrichModel]:
     """List all users in the system."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
         result = await session.execute(select(User))
         users = result.scalars().all()
-        
+
         return [
             UserEnrichModel(
                 id=user.id,
@@ -192,37 +322,34 @@ async def list_users(ctx: EnrichContext) -> List[UserEnrichModel]:
                 email=user.email,
                 full_name=user.full_name,
                 is_active=user.is_active,
-                created_at=user.created_at
+                created_at=user.created_at,
             )
             for user in users
         ]
 
 
 @app.resource
-async def get_user(user_id: int, ctx: EnrichContext) -> Optional[UserEnrichModel]:
+async def get_user(user_id: int, ctx: EnrichContext) -> UserEnrichModel | None:
     """Get a specific user by ID."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
         user = await session.get(User, user_id)
         if not user:
             return None
-            
+
         return UserEnrichModel(
             id=user.id,
             username=user.username,
             email=user.email,
             full_name=user.full_name,
             is_active=user.is_active,
-            created_at=user.created_at
+            created_at=user.created_at,
         )
 
 
 @app.resource
 async def list_products(
-    ctx: EnrichContext,
-    category: Optional[str] = None,
-    page: int = 1,
-    page_size: int = 20
+    ctx: EnrichContext, category: str | None = None, page: int = 1, page_size: int = 20
 ) -> PageResult[ProductEnrichModel]:
     """List products with optional filtering by category."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
@@ -231,16 +358,16 @@ async def list_products(
         query = select(Product)
         if category:
             query = query.where(Product.category == category)
-        
+
         # Get total count
         count_query = select(func.count()).select_from(query.subquery())
         total = await session.scalar(count_query)
-        
+
         # Get paginated results
         query = query.offset((page - 1) * page_size).limit(page_size)
         result = await session.execute(query)
         products = result.scalars().all()
-        
+
         items = [
             ProductEnrichModel(
                 id=product.id,
@@ -249,52 +376,49 @@ async def list_products(
                 price=product.price,
                 stock_quantity=product.stock_quantity,
                 category=product.category,
-                created_at=product.created_at
+                created_at=product.created_at,
             )
             for product in products
         ]
-        
+
         return PageResult.create(
             items=items,
             page=page,
             page_size=page_size,
             total_items=total,
-            has_next=page * page_size < total
+            has_next=page * page_size < total,
         )
 
 
 @app.resource
 async def list_orders(
-    ctx: EnrichContext,
-    status: Optional[str] = None,
-    cursor: Optional[str] = None,
-    limit: int = 10
+    ctx: EnrichContext, status: str | None = None, cursor: str | None = None, limit: int = 10
 ) -> CursorResult[OrderEnrichModel]:
     """List orders with cursor-based pagination."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
         # Build query
         query = select(Order)
-        
+
         # Apply status filter
         if status:
             query = query.where(Order.status == status)
-        
+
         # Apply cursor (assuming cursor is the last order ID seen)
         if cursor:
             query = query.where(Order.id > int(cursor))
-        
+
         # Order by ID for consistent cursor pagination
         query = query.order_by(Order.id).limit(limit + 1)
-        
+
         result = await session.execute(query)
         orders = result.scalars().all()
-        
+
         # Check if there are more results
         has_next = len(orders) > limit
         if has_next:
             orders = orders[:-1]  # Remove the extra item
-        
+
         items = [
             OrderEnrichModel(
                 id=order.id,
@@ -305,24 +429,21 @@ async def list_orders(
                 created_at=order.created_at,
                 updated_at=order.updated_at,
                 shipping_address=order.shipping_address,
-                notes=order.notes
+                notes=order.notes,
             )
             for order in orders
         ]
-        
+
         next_cursor = str(orders[-1].id) if orders else None
-        
+
         return CursorResult(
-            items=items,
-            next_cursor=next_cursor,
-            page_size=limit,
-            has_next=has_next
+            items=items, next_cursor=next_cursor, page_size=limit, has_next=has_next
         )
 
 
 # Manual relationship resolvers (until auto-generation is implemented)
 @UserEnrichModel.orders.resolver
-async def get_user_orders(user_id: int, ctx: EnrichContext) -> List["OrderEnrichModel"]:
+async def get_user_orders(user_id: int, ctx: EnrichContext) -> list["OrderEnrichModel"]:
     """Get all orders for a specific user."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
@@ -330,7 +451,7 @@ async def get_user_orders(user_id: int, ctx: EnrichContext) -> List["OrderEnrich
             select(Order).where(Order.user_id == user_id).order_by(Order.created_at.desc())
         )
         orders = result.scalars().all()
-        
+
         return [
             OrderEnrichModel(
                 id=order.id,
@@ -341,45 +462,43 @@ async def get_user_orders(user_id: int, ctx: EnrichContext) -> List["OrderEnrich
                 created_at=order.created_at,
                 updated_at=order.updated_at,
                 shipping_address=order.shipping_address,
-                notes=order.notes
+                notes=order.notes,
             )
             for order in orders
         ]
 
 
 @OrderEnrichModel.user.resolver
-async def get_order_user(order_id: int, ctx: EnrichContext) -> Optional[UserEnrichModel]:
+async def get_order_user(order_id: int, ctx: EnrichContext) -> UserEnrichModel | None:
     """Get the user who placed a specific order."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
         order = await session.get(Order, order_id)
         if not order:
             return None
-        
+
         # Load the user (SQLAlchemy will handle the join)
         await session.refresh(order, ["user"])
         user = order.user
-        
+
         return UserEnrichModel(
             id=user.id,
             username=user.username,
             email=user.email,
             full_name=user.full_name,
             is_active=user.is_active,
-            created_at=user.created_at
+            created_at=user.created_at,
         )
 
 
 @OrderEnrichModel.items.resolver
-async def get_order_items(order_id: int, ctx: EnrichContext) -> List["OrderItemEnrichModel"]:
+async def get_order_items(order_id: int, ctx: EnrichContext) -> list["OrderItemEnrichModel"]:
     """Get all items in a specific order."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
-        result = await session.execute(
-            select(OrderItem).where(OrderItem.order_id == order_id)
-        )
+        result = await session.execute(select(OrderItem).where(OrderItem.order_id == order_id))
         items = result.scalars().all()
-        
+
         return [
             OrderItemEnrichModel(
                 id=item.id,
@@ -387,7 +506,7 @@ async def get_order_items(order_id: int, ctx: EnrichContext) -> List["OrderItemE
                 product_id=item.product_id,
                 quantity=item.quantity,
                 unit_price=item.unit_price,
-                total_price=item.total_price
+                total_price=item.total_price,
             )
             for item in items
         ]
@@ -395,15 +514,15 @@ async def get_order_items(order_id: int, ctx: EnrichContext) -> List["OrderItemE
 
 # Add missing resolvers for Product and OrderItem relationships
 @ProductEnrichModel.order_items.resolver
-async def get_product_order_items(product_id: int, ctx: EnrichContext) -> List["OrderItemEnrichModel"]:
+async def get_product_order_items(
+    product_id: int, ctx: EnrichContext
+) -> list["OrderItemEnrichModel"]:
     """Get all order items for a specific product."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
-        result = await session.execute(
-            select(OrderItem).where(OrderItem.product_id == product_id)
-        )
+        result = await session.execute(select(OrderItem).where(OrderItem.product_id == product_id))
         items = result.scalars().all()
-        
+
         return [
             OrderItemEnrichModel(
                 id=item.id,
@@ -411,25 +530,27 @@ async def get_product_order_items(product_id: int, ctx: EnrichContext) -> List["
                 product_id=item.product_id,
                 quantity=item.quantity,
                 unit_price=item.unit_price,
-                total_price=item.total_price
+                total_price=item.total_price,
             )
             for item in items
         ]
 
 
 @OrderItemEnrichModel.order.resolver
-async def get_order_item_order(order_item_id: int, ctx: EnrichContext) -> Optional["OrderEnrichModel"]:
+async def get_order_item_order(
+    order_item_id: int, ctx: EnrichContext
+) -> Optional["OrderEnrichModel"]:
     """Get the order for a specific order item."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
         item = await session.get(OrderItem, order_item_id)
         if not item:
             return None
-        
+
         # Load the order
         await session.refresh(item, ["order"])
         order = item.order
-        
+
         return OrderEnrichModel(
             id=order.id,
             order_number=order.order_number,
@@ -439,23 +560,25 @@ async def get_order_item_order(order_item_id: int, ctx: EnrichContext) -> Option
             created_at=order.created_at,
             updated_at=order.updated_at,
             shipping_address=order.shipping_address,
-            notes=order.notes
+            notes=order.notes,
         )
 
 
 @OrderItemEnrichModel.product.resolver
-async def get_order_item_product(order_item_id: int, ctx: EnrichContext) -> Optional["ProductEnrichModel"]:
+async def get_order_item_product(
+    order_item_id: int, ctx: EnrichContext
+) -> Optional["ProductEnrichModel"]:
     """Get the product for a specific order item."""
     session_factory = ctx.request_context.lifespan_context["session_factory"]
     async with session_factory() as session:
         item = await session.get(OrderItem, order_item_id)
         if not item:
             return None
-        
+
         # Load the product
         await session.refresh(item, ["product"])
         product = item.product
-        
+
         return ProductEnrichModel(
             id=product.id,
             name=product.name,
@@ -463,125 +586,8 @@ async def get_order_item_product(order_item_id: int, ctx: EnrichContext) -> Opti
             price=product.price,
             stock_quantity=product.stock_quantity,
             category=product.category,
-            created_at=product.created_at
+            created_at=product.created_at,
         )
-
-
-async def seed_database(session: AsyncSession):
-    """Seed the database with sample data."""
-    # Create users
-    users = [
-        User(
-            username="john_doe",
-            email="john@example.com",
-            full_name="John Doe",
-            created_at=datetime.now()
-        ),
-        User(
-            username="jane_smith",
-            email="jane@example.com",
-            full_name="Jane Smith",
-            created_at=datetime.now()
-        ),
-    ]
-    session.add_all(users)
-    
-    # Create products
-    products = [
-        Product(
-            name="Laptop",
-            description="High-performance laptop",
-            price=999.99,
-            stock_quantity=50,
-            category="Electronics",
-            created_at=datetime.now()
-        ),
-        Product(
-            name="Wireless Mouse",
-            description="Ergonomic wireless mouse",
-            price=29.99,
-            stock_quantity=200,
-            category="Electronics",
-            created_at=datetime.now()
-        ),
-        Product(
-            name="USB-C Cable",
-            description="Fast charging USB-C cable",
-            price=19.99,
-            stock_quantity=500,
-            category="Accessories",
-            created_at=datetime.now()
-        ),
-        Product(
-            name="Coffee Maker",
-            description="Programmable coffee maker",
-            price=79.99,
-            stock_quantity=30,
-            category="Appliances",
-            created_at=datetime.now()
-        ),
-    ]
-    session.add_all(products)
-    
-    # Flush to get IDs
-    await session.flush()
-    
-    # Create orders
-    order1 = Order(
-        order_number="ORD-001",
-        user_id=users[0].id,
-        status="delivered",
-        total_amount=1029.98,
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        shipping_address="123 Main St, City, State 12345"
-    )
-    
-    order2 = Order(
-        order_number="ORD-002",
-        user_id=users[1].id,
-        status="processing",
-        total_amount=99.98,
-        created_at=datetime.now(),
-        updated_at=datetime.now(),
-        shipping_address="456 Oak Ave, Town, State 67890"
-    )
-    
-    session.add_all([order1, order2])
-    await session.flush()
-    
-    # Create order items
-    items = [
-        OrderItem(
-            order_id=order1.id,
-            product_id=products[0].id,  # Laptop
-            quantity=1,
-            unit_price=999.99,
-            total_price=999.99
-        ),
-        OrderItem(
-            order_id=order1.id,
-            product_id=products[1].id,  # Mouse
-            quantity=1,
-            unit_price=29.99,
-            total_price=29.99
-        ),
-        OrderItem(
-            order_id=order2.id,
-            product_id=products[3].id,  # Coffee Maker
-            quantity=1,
-            unit_price=79.99,
-            total_price=79.99
-        ),
-        OrderItem(
-            order_id=order2.id,
-            product_id=products[2].id,  # USB-C Cable
-            quantity=1,
-            unit_price=19.99,
-            total_price=19.99
-        ),
-    ]
-    session.add_all(items)
 
 
 if __name__ == "__main__":

--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -32,7 +32,6 @@ from .relationship import (
 )
 
 # Optional SQLAlchemy integration
-<<<<<<< HEAD
 has_sqlalchemy: bool = False
 try:  # pragma: no cover - optional dependency
     from .sqlalchemy import EnrichSQLAlchemyMixin, sqlalchemy_lifespan  # noqa: F401
@@ -40,14 +39,6 @@ except ImportError:  # pragma: no cover - optional dependency
     pass
 else:
     has_sqlalchemy = True
-=======
-try:
-    from .sqlalchemy import EnrichSQLAlchemyMixin  # noqa: F401
-
-    HAS_SQLALCHEMY = True  # pyright: ignore[reportConstantRedefinition]
-except ImportError:
-    HAS_SQLALCHEMY = False  # pyright: ignore[reportConstantRedefinition]
->>>>>>> feature/sqlalchemy-support/simba
 
 __all__ = [
     "CursorParams",
@@ -64,10 +55,5 @@ __all__ = [
 ]
 
 # Add SQLAlchemy to exports if available
-<<<<<<< HEAD
 if has_sqlalchemy:
     __all__.extend(["EnrichSQLAlchemyMixin", "sqlalchemy_lifespan"])
-=======
-if HAS_SQLALCHEMY:
-    __all__.append("EnrichSQLAlchemyMixin")
->>>>>>> feature/sqlalchemy-support/simba

--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -32,12 +32,13 @@ from .relationship import (
 )
 
 # Optional SQLAlchemy integration
+has_sqlalchemy: bool = False
 try:  # pragma: no cover - optional dependency
     from .sqlalchemy import EnrichSQLAlchemyMixin, sqlalchemy_lifespan  # noqa: F401
 except ImportError:  # pragma: no cover - optional dependency
-    _HAS_SQLALCHEMY = False
+    pass
 else:
-    _HAS_SQLALCHEMY = True
+    has_sqlalchemy = True
 
 __all__ = [
     "CursorParams",
@@ -54,5 +55,5 @@ __all__ = [
 ]
 
 # Add SQLAlchemy to exports if available
-if _HAS_SQLALCHEMY:
+if has_sqlalchemy:
     __all__.extend(["EnrichSQLAlchemyMixin", "sqlalchemy_lifespan"])

--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -25,17 +25,19 @@ except ImportError:
 from .app import EnrichMCP
 from .context import EnrichContext
 from .entity import EnrichModel
+from .lifespan import combine_lifespans
 from .pagination import CursorParams, CursorResult, PageResult, PaginatedResult, PaginationParams
 from .relationship import (
     Relationship,
 )
 
 # Optional SQLAlchemy integration
-try:
-    from .sqlalchemy import EnrichSQLAlchemyMixin
-    _HAS_SQLALCHEMY = True
-except ImportError:
+try:  # pragma: no cover - optional dependency
+    from .sqlalchemy import EnrichSQLAlchemyMixin, sqlalchemy_lifespan  # noqa: F401
+except ImportError:  # pragma: no cover - optional dependency
     _HAS_SQLALCHEMY = False
+else:
+    _HAS_SQLALCHEMY = True
 
 __all__ = [
     "CursorParams",
@@ -48,8 +50,9 @@ __all__ = [
     "PaginationParams",
     "Relationship",
     "__version__",
+    "combine_lifespans",
 ]
 
 # Add SQLAlchemy to exports if available
 if _HAS_SQLALCHEMY:
-    __all__.append("EnrichSQLAlchemyMixin")
+    __all__.extend(["EnrichSQLAlchemyMixin", "sqlalchemy_lifespan"])

--- a/src/enrichmcp/lifespan.py
+++ b/src/enrichmcp/lifespan.py
@@ -1,0 +1,32 @@
+"""Utility helpers for combining lifespan context managers."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+from contextlib import AsyncExitStack, asynccontextmanager
+from typing import Any
+
+from .app import EnrichMCP
+
+Lifespan = Callable[[EnrichMCP], AsyncIterator[dict[str, Any]]]
+
+
+def combine_lifespans(*lifespans: Lifespan) -> Lifespan:
+    """Combine multiple lifespan functions into one.
+
+    Each lifespan may yield a dict of context values. The returned context will
+    merge all of these dictionaries. Later lifespans override keys from earlier
+    ones if they conflict.
+    """
+
+    @asynccontextmanager
+    async def _combined(app: EnrichMCP) -> AsyncIterator[dict[str, Any]]:
+        async with AsyncExitStack() as stack:
+            merged: dict[str, Any] = {}
+            for ls in lifespans:
+                ctx = await stack.enter_async_context(ls(app))
+                if isinstance(ctx, dict):
+                    merged.update(ctx)
+            yield merged
+
+    return _combined

--- a/src/enrichmcp/sqlalchemy/__init__.py
+++ b/src/enrichmcp/sqlalchemy/__init__.py
@@ -4,6 +4,7 @@ SQLAlchemy integration for EnrichMCP.
 This module provides utilities to convert SQLAlchemy models to EnrichModel representations.
 """
 
+from .lifecycle import sqlalchemy_lifespan
 from .mixin import EnrichSQLAlchemyMixin
 
-__all__ = ["EnrichSQLAlchemyMixin"]
+__all__ = ["EnrichSQLAlchemyMixin", "sqlalchemy_lifespan"]

--- a/src/enrichmcp/sqlalchemy/lifecycle.py
+++ b/src/enrichmcp/sqlalchemy/lifecycle.py
@@ -1,0 +1,46 @@
+"""Default SQLAlchemy lifespan helpers."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker
+
+from enrichmcp.app import EnrichMCP
+
+if TYPE_CHECKING:  # pragma: no cover - type checking import
+    from sqlalchemy.orm import DeclarativeBase
+
+Lifespan = Callable[[EnrichMCP], AsyncIterator[dict[str, Any]]]
+
+
+def sqlalchemy_lifespan(
+    base: type[DeclarativeBase],
+    engine: AsyncEngine,
+    *,
+    seed: Callable[[AsyncSession], Awaitable[None]] | None = None,
+    session_kwargs: dict[str, Any] | None = None,
+) -> Lifespan:
+    """Create a lifespan that sets up tables and yields a session factory."""
+
+    session_kwargs = session_kwargs or {}
+
+    @asynccontextmanager
+    async def _lifespan(app: EnrichMCP) -> AsyncIterator[dict[str, Any]]:
+        async with engine.begin() as conn:
+            await conn.run_sync(base.metadata.create_all)
+        session_factory = async_sessionmaker(
+            engine, class_=AsyncSession, expire_on_commit=False, **session_kwargs
+        )
+        if seed is not None:
+            async with session_factory() as session:
+                await seed(session)
+                await session.commit()
+        try:
+            yield {"session_factory": session_factory}
+        finally:
+            await engine.dispose()
+
+    return _lifespan

--- a/src/enrichmcp/sqlalchemy/mixin.py
+++ b/src/enrichmcp/sqlalchemy/mixin.py
@@ -8,13 +8,7 @@ from typing import Any
 
 from pydantic import Field, create_model
 from sqlalchemy import inspect
-<<<<<<< HEAD
 from sqlalchemy.orm import DeclarativeBase
-=======
-from sqlalchemy.orm import (
-    DeclarativeBase,  # pyright: ignore[reportMissingModuleSource, reportAttributeAccessIssue, reportUnknownVariableType]
-)
->>>>>>> feature/sqlalchemy-support/simba
 from sqlalchemy.sql.type_api import TypeEngine
 
 from enrichmcp import EnrichModel, Relationship
@@ -87,12 +81,7 @@ class EnrichSQLAlchemyMixin:
 
             # Get description
             description = rel_info.get(
-<<<<<<< HEAD
                 "description", f"Relationship to {rel_prop.mapper.class_.__name__}EnrichModel"
-=======
-                "description",
-                f"Relationship to {rel_prop.mapper.class_.__name__}EnrichModel",
->>>>>>> feature/sqlalchemy-support/simba
             )
 
             # Determine relationship type
@@ -125,20 +114,12 @@ class EnrichSQLAlchemyMixin:
 
         # Store reference to original SQLAlchemy model
         # Use setattr to ensure it's properly set on the class
-<<<<<<< HEAD
         enrich_model_class._sqlalchemy_model = cls
-=======
-        enrich_model_class._sqlalchemy_model = cls  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
->>>>>>> feature/sqlalchemy-support/simba
 
         return enrich_model_class
 
 
-<<<<<<< HEAD
 def _sqlalchemy_type_to_python(sa_type: TypeEngine) -> type:
-=======
-def _sqlalchemy_type_to_python(sa_type: TypeEngine[Any]) -> type[Any]:
->>>>>>> feature/sqlalchemy-support/simba
     """
     Convert SQLAlchemy type to Python type.
 
@@ -188,4 +169,4 @@ def _sqlalchemy_type_to_python(sa_type: TypeEngine[Any]) -> type[Any]:
             return py_type
 
     # Default to Any for unknown types
-    return Any  # pyright: ignore[reportReturnType]
+    return Any

--- a/src/enrichmcp/sqlalchemy/mixin.py
+++ b/src/enrichmcp/sqlalchemy/mixin.py
@@ -4,11 +4,11 @@ SQLAlchemy mixin for EnrichMCP integration.
 Provides functionality to convert SQLAlchemy models to EnrichModel representations.
 """
 
-from typing import Any, Dict, List, Optional, Type, Union, get_args, get_origin
+from typing import Any
 
 from pydantic import Field, create_model
 from sqlalchemy import inspect
-from sqlalchemy.orm import DeclarativeBase, Mapped, RelationshipProperty
+from sqlalchemy.orm import DeclarativeBase
 from sqlalchemy.sql.type_api import TypeEngine
 
 from enrichmcp import EnrichModel, Relationship
@@ -17,51 +17,51 @@ from enrichmcp import EnrichModel, Relationship
 class EnrichSQLAlchemyMixin:
     """
     Mixin that enables SQLAlchemy models to be converted to EnrichModel representations.
-    
+
     When a SQLAlchemy model inherits from this mixin and is registered with @app.entity,
     it will automatically generate an EnrichModel representation with proper field types
     and descriptions from the SQLAlchemy column metadata.
     """
-    
+
     @classmethod
-    def __enrich_model__(cls) -> Type[EnrichModel]:
+    def __enrich_model__(cls) -> type[EnrichModel]:
         """
         Convert this SQLAlchemy model to an EnrichModel representation.
-        
+
         This method introspects the SQLAlchemy model and creates a corresponding
         EnrichModel with fields and relationships based on the SQLAlchemy metadata.
-        
+
         Returns:
             A dynamically created EnrichModel class
         """
         if not issubclass(cls, DeclarativeBase):
             raise TypeError(f"{cls.__name__} must inherit from SQLAlchemy DeclarativeBase")
-        
+
         # Get SQLAlchemy mapper
         mapper = inspect(cls)
-        
+
         # Build field definitions for the EnrichModel
-        field_definitions: Dict[str, Any] = {}
-        
+        field_definitions: dict[str, Any] = {}
+
         # Process columns
         for column_prop in mapper.column_attrs:
             column = column_prop.columns[0]
             field_name = column_prop.key
-            
+
             # Skip fields marked with exclude in info
             if column.info.get("exclude", False):
                 continue
-            
+
             # Get Python type from SQLAlchemy column type
             python_type = _sqlalchemy_type_to_python(column.type)
-            
+
             # Handle nullable columns
             if column.nullable:
-                python_type = Optional[python_type]
-            
+                python_type = python_type | None
+
             # Get description from column info
             description = column.info.get("description", f"{field_name} field")
-            
+
             # Create Pydantic Field
             if column.default is not None or column.server_default is not None:
                 # Has default value
@@ -69,71 +69,82 @@ class EnrichSQLAlchemyMixin:
             else:
                 # Required field
                 field_definitions[field_name] = (python_type, Field(description=description))
-        
+
         # Process relationships
         for rel_prop in mapper.relationships:
             field_name = rel_prop.key
             rel_info = rel_prop.info
-            
+
             # Skip relationships marked with exclude
             if rel_info.get("exclude", False):
                 continue
-            
+
             # Get description
-            description = rel_info.get("description", f"Relationship to {rel_prop.mapper.class_.__name__}EnrichModel")
-            
+            description = rel_info.get(
+                "description", f"Relationship to {rel_prop.mapper.class_.__name__}EnrichModel"
+            )
+
             # Determine relationship type
             if rel_prop.uselist:
                 # One-to-many or many-to-many relationship
                 target_class_name = rel_prop.mapper.class_.__name__
                 # Map to EnrichModel version of the class
                 enrich_target_name = f"{target_class_name}EnrichModel"
-                rel_type = List[enrich_target_name]  # Using string forward reference
+                rel_type = list[enrich_target_name]  # Using string forward reference
             else:
                 # One-to-one or many-to-one relationship
                 target_class_name = rel_prop.mapper.class_.__name__
                 # Map to EnrichModel version of the class
                 enrich_target_name = f"{target_class_name}EnrichModel"
                 rel_type = enrich_target_name
-            
+
             # Create Relationship field
             field_definitions[field_name] = (rel_type, Relationship(description=description))
-        
+
         # Get model documentation
         model_doc = cls.__doc__ or f"{cls.__name__} entity"
-        
+
         # Create the EnrichModel class dynamically
         enrich_model_class = create_model(
             f"{cls.__name__}EnrichModel",
             __base__=EnrichModel,
             __doc__=model_doc,
-            **field_definitions
+            **field_definitions,
         )
-        
+
         # Store reference to original SQLAlchemy model
         # Use setattr to ensure it's properly set on the class
-        setattr(enrich_model_class, '_sqlalchemy_model', cls)
-        
+        enrich_model_class._sqlalchemy_model = cls
+
         return enrich_model_class
 
 
-def _sqlalchemy_type_to_python(sa_type: TypeEngine) -> Type:
+def _sqlalchemy_type_to_python(sa_type: TypeEngine) -> type:
     """
     Convert SQLAlchemy type to Python type.
-    
+
     Args:
         sa_type: SQLAlchemy TypeEngine instance
-        
+
     Returns:
         Corresponding Python type
     """
     # Import here to avoid circular dependencies
-    from sqlalchemy import (
-        Boolean, Date, DateTime, Float, Integer, 
-        String, Text, Time, JSON, LargeBinary
-    )
     from datetime import date, datetime, time
-    
+
+    from sqlalchemy import (
+        JSON,
+        Boolean,
+        Date,
+        DateTime,
+        Float,
+        Integer,
+        LargeBinary,
+        String,
+        Text,
+        Time,
+    )
+
     type_map = {
         Integer: int,
         String: str,
@@ -146,16 +157,16 @@ def _sqlalchemy_type_to_python(sa_type: TypeEngine) -> Type:
         JSON: dict,
         LargeBinary: bytes,
     }
-    
+
     # Check for exact type matches first
     for sa_class, py_type in type_map.items():
         if type(sa_type) is sa_class:
             return py_type
-    
+
     # Check for inheritance
     for sa_class, py_type in type_map.items():
         if isinstance(sa_type, sa_class):
             return py_type
-    
+
     # Default to Any for unknown types
     return Any

--- a/tests/test_sqlalchemy_integration.py
+++ b/tests/test_sqlalchemy_integration.py
@@ -2,17 +2,12 @@
 Tests for SQLAlchemy integration with EnrichMCP.
 """
 
-<<<<<<< HEAD
 # ruff: noqa: N806,E721
 
+import types
 from datetime import date, datetime
 from typing import Union, get_args, get_origin
 
-=======
-from datetime import date, datetime
-from typing import Union, get_args, get_origin
-
->>>>>>> feature/sqlalchemy-support/simba
 import pytest
 from sqlalchemy import (
     Boolean,
@@ -49,7 +44,6 @@ class TestBasicModel:
             username: Mapped[str] = mapped_column(info={"description": "Username"})
             email: Mapped[str] = mapped_column(info={"description": "Email address"})
             is_active: Mapped[bool] = mapped_column(
-<<<<<<< HEAD
                 default=True, info={"description": "Active status"}
             )
 
@@ -58,37 +52,19 @@ class TestBasicModel:
 
         # Check that it's a proper EnrichModel subclass
         assert issubclass(UserEnrichModel, EnrichModel)
-=======
-                default=True,
-                info={"description": "Active status"},
-            )
-
-        # Convert to EnrichModel
-        user_enrich_model = User.__enrich_model__()
-
-        # Check that it's a proper EnrichModel subclass
-        assert issubclass(user_enrich_model, EnrichModel)
->>>>>>> feature/sqlalchemy-support/simba
 
         # Check fields exist
-        fields = user_enrich_model.model_fields
+        fields = UserEnrichModel.model_fields
         assert "id" in fields
         assert "username" in fields
         assert "email" in fields
         assert "is_active" in fields
 
         # Check field types
-<<<<<<< HEAD
         assert fields["id"].annotation == int
         assert fields["username"].annotation == str
         assert fields["email"].annotation == str
         assert fields["is_active"].annotation == bool
-=======
-        assert fields["id"].annotation is int
-        assert fields["username"].annotation is str
-        assert fields["email"].annotation is str
-        assert fields["is_active"].annotation is bool
->>>>>>> feature/sqlalchemy-support/simba
 
         # Check descriptions
         assert fields["id"].description == "User ID"
@@ -108,7 +84,6 @@ class TestBasicModel:
             id: Mapped[int] = mapped_column(primary_key=True)
             name: Mapped[str] = mapped_column(nullable=False)
             description: Mapped[str | None] = mapped_column(
-<<<<<<< HEAD
                 nullable=True, info={"description": "Product description"}
             )
             price: Mapped[float | None] = mapped_column(nullable=True)
@@ -119,19 +94,6 @@ class TestBasicModel:
         # Non-nullable fields should not be Optional
         assert fields["id"].annotation == int
         assert fields["name"].annotation == str
-=======
-                nullable=True,
-                info={"description": "Product description"},
-            )
-            price: Mapped[float | None] = mapped_column(nullable=True)
-
-        product_enrich_model = Product.__enrich_model__()
-        fields = product_enrich_model.model_fields
-
-        # Non-nullable fields should not be Optional
-        assert fields["id"].annotation is int
-        assert fields["name"].annotation is str
->>>>>>> feature/sqlalchemy-support/simba
 
         # Nullable fields should be Optional
         # Check if it's Optional by looking at the annotation
@@ -139,11 +101,11 @@ class TestBasicModel:
         price_type = fields["price"].annotation
 
         # In Python 3.10+, Optional[X] is Union[X, None]
-        assert get_origin(desc_type) is Union
+        assert get_origin(desc_type) in {Union, types.UnionType}
         assert type(None) in get_args(desc_type)
         assert str in get_args(desc_type)
 
-        assert get_origin(price_type) is Union
+        assert get_origin(price_type) in {Union, types.UnionType}
         assert type(None) in get_args(price_type)
         assert float in get_args(price_type)
 
@@ -160,19 +122,11 @@ class TestBasicModel:
             username: Mapped[str] = mapped_column()
             password_hash: Mapped[str] = mapped_column(info={"exclude": True})
             secret_token: Mapped[str] = mapped_column(
-<<<<<<< HEAD
                 info={"exclude": True, "description": "Should not appear"}
             )
 
         UserEnrichModel = User.__enrich_model__()
         fields = UserEnrichModel.model_fields
-=======
-                info={"exclude": True, "description": "Should not appear"},
-            )
-
-        user_enrich_model = User.__enrich_model__()
-        fields = user_enrich_model.model_fields
->>>>>>> feature/sqlalchemy-support/simba
 
         # Check included fields
         assert "id" in fields
@@ -199,27 +153,18 @@ class TestBasicModel:
             created_at: Mapped[datetime] = mapped_column(DateTime)
             birth_date: Mapped[date] = mapped_column(Date)
 
-<<<<<<< HEAD
         DataTypesEnrichModel = DataTypes.__enrich_model__()
         fields = DataTypesEnrichModel.model_fields
-=======
-        data_types_enrich_model = DataTypes.__enrich_model__()
-        fields = data_types_enrich_model.model_fields
->>>>>>> feature/sqlalchemy-support/simba
 
         # Check type conversions
-        assert fields["id"].annotation is int
-        assert fields["name"].annotation is str
-        assert fields["description"].annotation is str
-        assert fields["is_active"].annotation is bool
-        assert fields["price"].annotation is float
-        assert fields["created_at"].annotation is datetime
+        assert fields["id"].annotation == int
+        assert fields["name"].annotation == str
+        assert fields["description"].annotation == str
+        assert fields["is_active"].annotation == bool
+        assert fields["price"].annotation == float
+        assert fields["created_at"].annotation == datetime
         # Date type should be converted properly
-<<<<<<< HEAD
         assert fields["birth_date"].annotation == date
-=======
-        assert fields["birth_date"].annotation is date
->>>>>>> feature/sqlalchemy-support/simba
 
     def test_model_documentation(self):
         """Test that model docstring is preserved."""
@@ -235,13 +180,8 @@ class TestBasicModel:
             id: Mapped[int] = mapped_column(primary_key=True)
             total: Mapped[float] = mapped_column()
 
-<<<<<<< HEAD
         OrderEnrichModel = Order.__enrich_model__()
         assert OrderEnrichModel.__doc__ == "Order represents a customer purchase."
-=======
-        order_enrich_model = Order.__enrich_model__()
-        assert order_enrich_model.__doc__ == "Order represents a customer purchase."
->>>>>>> feature/sqlalchemy-support/simba
 
     def test_default_descriptions(self):
         """Test that fields without descriptions get default ones."""
@@ -255,13 +195,8 @@ class TestBasicModel:
             id: Mapped[int] = mapped_column(primary_key=True)
             name: Mapped[str] = mapped_column()  # No description in info
 
-<<<<<<< HEAD
         ItemEnrichModel = Item.__enrich_model__()
         fields = ItemEnrichModel.model_fields
-=======
-        item_enrich_model = Item.__enrich_model__()
-        fields = item_enrich_model.model_fields
->>>>>>> feature/sqlalchemy-support/simba
 
         # Should have default descriptions
         assert fields["id"].description == "id field"
@@ -296,22 +231,17 @@ class TestRelationships:
             )
 
         # Convert to EnrichModel
-<<<<<<< HEAD
         UserEnrichModel = User.__enrich_model__()
         fields = UserEnrichModel.model_fields
-=======
-        user_enrich_model = User.__enrich_model__()
-        fields = user_enrich_model.model_fields
->>>>>>> feature/sqlalchemy-support/simba
 
         # Check that orders field exists and is a Relationship
         assert "orders" in fields
         assert isinstance(fields["orders"].default, Relationship)
         assert fields["orders"].default.description == "User's orders"
 
-        # Check the type annotation (should be List["OrderEnrichModel"])
+        # Check the type annotation (should be list["OrderEnrichModel"])
         # The annotation will be a string forward reference
-        assert "List" in str(fields["orders"].annotation)
+        assert "list" in str(fields["orders"].annotation)
         assert "OrderEnrichModel" in str(fields["orders"].annotation)
 
     def test_many_to_one_relationship(self):
@@ -335,13 +265,8 @@ class TestRelationships:
             id: Mapped[int] = mapped_column(primary_key=True)
             username: Mapped[str] = mapped_column()
 
-<<<<<<< HEAD
         OrderEnrichModel = Order.__enrich_model__()
         fields = OrderEnrichModel.model_fields
-=======
-        order_enrich_model = Order.__enrich_model__()
-        fields = order_enrich_model.model_fields
->>>>>>> feature/sqlalchemy-support/simba
 
         # Check that user field exists and is a Relationship
         assert "user" in fields
@@ -375,13 +300,8 @@ class TestRelationships:
             id: Mapped[int] = mapped_column(primary_key=True)
             user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
 
-<<<<<<< HEAD
         UserEnrichModel = User.__enrich_model__()
         fields = UserEnrichModel.model_fields
-=======
-        user_enrich_model = User.__enrich_model__()
-        fields = user_enrich_model.model_fields
->>>>>>> feature/sqlalchemy-support/simba
 
         # Check that excluded relationship is not included
         assert "secret_orders" not in fields
@@ -405,13 +325,8 @@ class TestRelationships:
             id: Mapped[int] = mapped_column(primary_key=True)
             user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
 
-<<<<<<< HEAD
         UserEnrichModel = User.__enrich_model__()
         fields = UserEnrichModel.model_fields
-=======
-        user_enrich_model = User.__enrich_model__()
-        fields = user_enrich_model.model_fields
->>>>>>> feature/sqlalchemy-support/simba
 
         assert "posts" in fields
         assert isinstance(fields["posts"].default, Relationship)
@@ -444,13 +359,8 @@ class TestEdgeCases:
             __tablename__ = "no_doc"
             id: Mapped[int] = mapped_column(primary_key=True)
 
-<<<<<<< HEAD
         NoDocEnrichModel = NoDoc.__enrich_model__()
         assert NoDocEnrichModel.__doc__ == "NoDoc entity"
-=======
-        no_doc_enrich_model = NoDoc.__enrich_model__()
-        assert no_doc_enrich_model.__doc__ == "NoDoc entity"
->>>>>>> feature/sqlalchemy-support/simba
 
     def test_async_attrs_compatibility(self):
         """Test that the mixin works with AsyncAttrs."""
@@ -467,17 +377,10 @@ class TestEdgeCases:
             username: Mapped[str] = mapped_column()
 
         # Should work without issues
-<<<<<<< HEAD
         AsyncUserEnrichModel = AsyncUser.__enrich_model__()
         assert issubclass(AsyncUserEnrichModel, EnrichModel)
         assert "id" in AsyncUserEnrichModel.model_fields
         assert "username" in AsyncUserEnrichModel.model_fields
-=======
-        async_user_enrich_model = AsyncUser.__enrich_model__()
-        assert issubclass(async_user_enrich_model, EnrichModel)
-        assert "id" in async_user_enrich_model.model_fields
-        assert "username" in async_user_enrich_model.model_fields
->>>>>>> feature/sqlalchemy-support/simba
 
     def test_generated_model_name(self):
         """Test that generated EnrichModel has correct name."""
@@ -489,13 +392,8 @@ class TestEdgeCases:
             __tablename__ = "customers"
             id: Mapped[int] = mapped_column(primary_key=True)
 
-<<<<<<< HEAD
         CustomerEnrichModel = Customer.__enrich_model__()
         assert CustomerEnrichModel.__name__ == "CustomerEnrichModel"
-=======
-        customer_enrich_model = Customer.__enrich_model__()
-        assert customer_enrich_model.__name__ == "CustomerEnrichModel"
->>>>>>> feature/sqlalchemy-support/simba
 
     def test_model_inheritance(self):
         """Test that the EnrichModel properly inherits from EnrichModel base."""
@@ -508,7 +406,6 @@ class TestEdgeCases:
             id: Mapped[int] = mapped_column(primary_key=True)
             name: Mapped[str] = mapped_column()
 
-<<<<<<< HEAD
         ProductEnrichModel = Product.__enrich_model__()
 
         # Should be a proper EnrichModel with all its methods
@@ -516,15 +413,6 @@ class TestEdgeCases:
         assert hasattr(ProductEnrichModel, "model_dump_json")
         assert hasattr(ProductEnrichModel, "relationship_fields")
         assert hasattr(ProductEnrichModel, "describe")
-=======
-        product_enrich_model = Product.__enrich_model__()
-
-        # Should be a proper EnrichModel with all its methods
-        assert hasattr(product_enrich_model, "model_dump")
-        assert hasattr(product_enrich_model, "model_dump_json")
-        assert hasattr(product_enrich_model, "relationship_fields")
-        assert hasattr(product_enrich_model, "describe")
->>>>>>> feature/sqlalchemy-support/simba
 
     def test_sqlalchemy_model_reference_stored(self):
         """Test that reference to original SQLAlchemy model is stored."""
@@ -536,15 +424,9 @@ class TestEdgeCases:
             __tablename__ = "orders"
             id: Mapped[int] = mapped_column(primary_key=True)
 
-<<<<<<< HEAD
         OrderEnrichModel = Order.__enrich_model__()
         assert hasattr(OrderEnrichModel, "_sqlalchemy_model")
         assert OrderEnrichModel._sqlalchemy_model is Order
-=======
-        order_enrich_model = Order.__enrich_model__()
-        assert hasattr(order_enrich_model, "_sqlalchemy_model")
-        assert order_enrich_model._sqlalchemy_model is Order
->>>>>>> feature/sqlalchemy-support/simba
 
 
 class TestComplexScenarios:
@@ -566,18 +448,10 @@ class TestComplexScenarios:
             username: Mapped[str] = mapped_column(info={"description": "Display name"})
             password_hash: Mapped[str] = mapped_column(info={"exclude": True})
             created_at: Mapped[datetime] = mapped_column(
-<<<<<<< HEAD
                 info={"description": "Account creation time"}
             )
             is_active: Mapped[bool] = mapped_column(
                 default=True, info={"description": "Account status"}
-=======
-                info={"description": "Account creation time"},
-            )
-            is_active: Mapped[bool] = mapped_column(
-                default=True,
-                info={"description": "Account status"},
->>>>>>> feature/sqlalchemy-support/simba
             )
 
             orders: Mapped[list["Order"]] = relationship(
@@ -636,20 +510,13 @@ class TestComplexScenarios:
             product: Mapped[Product] = relationship(back_populates="reviews")
 
         # Convert all models
-<<<<<<< HEAD
         UserEnrichModel = User.__enrich_model__()
         ProductEnrichModel = Product.__enrich_model__()
         OrderEnrichModel = Order.__enrich_model__()
         ReviewEnrichModel = Review.__enrich_model__()
-=======
-        user_enrich_model = User.__enrich_model__()
-        product_enrich_model = Product.__enrich_model__()
-        order_enrich_model = Order.__enrich_model__()
-        review_enrich_model = Review.__enrich_model__()
->>>>>>> feature/sqlalchemy-support/simba
 
         # Verify User model
-        user_fields = user_enrich_model.model_fields
+        user_fields = UserEnrichModel.model_fields
         assert "id" in user_fields
         assert "email" in user_fields
         assert "username" in user_fields
@@ -664,15 +531,10 @@ class TestComplexScenarios:
         assert isinstance(user_fields["reviews"].default, Relationship)
 
         # Verify Order model
-        order_fields = order_enrich_model.model_fields
+        order_fields = OrderEnrichModel.model_fields
         assert "user" in order_fields
         assert isinstance(order_fields["user"].default, Relationship)
 
         # Verify all models are proper EnrichModels
-        for model in [
-            user_enrich_model,
-            product_enrich_model,
-            order_enrich_model,
-            review_enrich_model,
-        ]:
+        for model in [UserEnrichModel, ProductEnrichModel, OrderEnrichModel, ReviewEnrichModel]:
             assert issubclass(model, EnrichModel)

--- a/tests/test_sqlalchemy_integration.py
+++ b/tests/test_sqlalchemy_integration.py
@@ -2,16 +2,24 @@
 Tests for SQLAlchemy integration with EnrichMCP.
 """
 
-import pytest
-from datetime import datetime, date
-from typing import List, Optional, Union, get_origin, get_args
+# ruff: noqa: N806,E721
 
+from datetime import date, datetime
+from typing import Union, get_args, get_origin
+
+import pytest
 from sqlalchemy import (
-    Column, Integer, String, Boolean, Float, DateTime, 
-    ForeignKey, Text, create_engine, Date
+    Boolean,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
 )
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship, Session
 from sqlalchemy.ext.asyncio import AsyncAttrs
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from enrichmcp import EnrichModel, Relationship
 from enrichmcp.sqlalchemy import EnrichSQLAlchemyMixin
@@ -19,116 +27,123 @@ from enrichmcp.sqlalchemy import EnrichSQLAlchemyMixin
 
 class TestBasicModel:
     """Test basic SQLAlchemy model conversion."""
-    
+
     def test_simple_model_conversion(self):
         """Test converting a simple SQLAlchemy model to EnrichModel."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class User(Base, EnrichSQLAlchemyMixin):
             """User entity for testing."""
+
             __tablename__ = "users"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True, info={"description": "User ID"})
             username: Mapped[str] = mapped_column(info={"description": "Username"})
             email: Mapped[str] = mapped_column(info={"description": "Email address"})
-            is_active: Mapped[bool] = mapped_column(default=True, info={"description": "Active status"})
-        
+            is_active: Mapped[bool] = mapped_column(
+                default=True, info={"description": "Active status"}
+            )
+
         # Convert to EnrichModel
         UserEnrichModel = User.__enrich_model__()
-        
+
         # Check that it's a proper EnrichModel subclass
         assert issubclass(UserEnrichModel, EnrichModel)
-        
+
         # Check fields exist
         fields = UserEnrichModel.model_fields
         assert "id" in fields
         assert "username" in fields
         assert "email" in fields
         assert "is_active" in fields
-        
+
         # Check field types
         assert fields["id"].annotation == int
         assert fields["username"].annotation == str
         assert fields["email"].annotation == str
         assert fields["is_active"].annotation == bool
-        
+
         # Check descriptions
         assert fields["id"].description == "User ID"
         assert fields["username"].description == "Username"
         assert fields["email"].description == "Email address"
         assert fields["is_active"].description == "Active status"
-    
+
     def test_nullable_columns(self):
         """Test that nullable columns are converted to Optional types."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class Product(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "products"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             name: Mapped[str] = mapped_column(nullable=False)
-            description: Mapped[Optional[str]] = mapped_column(nullable=True, info={"description": "Product description"})
-            price: Mapped[Optional[float]] = mapped_column(nullable=True)
-        
+            description: Mapped[str | None] = mapped_column(
+                nullable=True, info={"description": "Product description"}
+            )
+            price: Mapped[float | None] = mapped_column(nullable=True)
+
         ProductEnrichModel = Product.__enrich_model__()
         fields = ProductEnrichModel.model_fields
-        
+
         # Non-nullable fields should not be Optional
         assert fields["id"].annotation == int
         assert fields["name"].annotation == str
-        
+
         # Nullable fields should be Optional
         # Check if it's Optional by looking at the annotation
         desc_type = fields["description"].annotation
         price_type = fields["price"].annotation
-        
+
         # In Python 3.10+, Optional[X] is Union[X, None]
         assert get_origin(desc_type) is Union
         assert type(None) in get_args(desc_type)
         assert str in get_args(desc_type)
-        
+
         assert get_origin(price_type) is Union
         assert type(None) in get_args(price_type)
         assert float in get_args(price_type)
-    
+
     def test_excluded_fields(self):
         """Test that fields marked with exclude=True are not included."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class User(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "users"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             username: Mapped[str] = mapped_column()
             password_hash: Mapped[str] = mapped_column(info={"exclude": True})
-            secret_token: Mapped[str] = mapped_column(info={"exclude": True, "description": "Should not appear"})
-        
+            secret_token: Mapped[str] = mapped_column(
+                info={"exclude": True, "description": "Should not appear"}
+            )
+
         UserEnrichModel = User.__enrich_model__()
         fields = UserEnrichModel.model_fields
-        
+
         # Check included fields
         assert "id" in fields
         assert "username" in fields
-        
+
         # Check excluded fields
         assert "password_hash" not in fields
         assert "secret_token" not in fields
-    
+
     def test_various_column_types(self):
         """Test conversion of various SQLAlchemy column types."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class DataTypes(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "data_types"
-            
+
             id: Mapped[int] = mapped_column(Integer, primary_key=True)
             name: Mapped[str] = mapped_column(String(100))
             description: Mapped[str] = mapped_column(Text)
@@ -136,10 +151,10 @@ class TestBasicModel:
             price: Mapped[float] = mapped_column(Float)
             created_at: Mapped[datetime] = mapped_column(DateTime)
             birth_date: Mapped[date] = mapped_column(Date)
-        
+
         DataTypesEnrichModel = DataTypes.__enrich_model__()
         fields = DataTypesEnrichModel.model_fields
-        
+
         # Check type conversions
         assert fields["id"].annotation == int
         assert fields["name"].annotation == str
@@ -149,38 +164,39 @@ class TestBasicModel:
         assert fields["created_at"].annotation == datetime
         # Date type should be converted properly
         assert fields["birth_date"].annotation == date
-    
+
     def test_model_documentation(self):
         """Test that model docstring is preserved."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class Order(Base, EnrichSQLAlchemyMixin):
             """Order represents a customer purchase."""
+
             __tablename__ = "orders"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             total: Mapped[float] = mapped_column()
-        
+
         OrderEnrichModel = Order.__enrich_model__()
         assert OrderEnrichModel.__doc__ == "Order represents a customer purchase."
-    
+
     def test_default_descriptions(self):
         """Test that fields without descriptions get default ones."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class Item(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "items"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             name: Mapped[str] = mapped_column()  # No description in info
-        
+
         ItemEnrichModel = Item.__enrich_model__()
         fields = ItemEnrichModel.model_fields
-        
+
         # Should have default descriptions
         assert fields["id"].description == "id field"
         assert fields["name"].description == "name field"
@@ -188,133 +204,129 @@ class TestBasicModel:
 
 class TestRelationships:
     """Test SQLAlchemy relationship conversion."""
-    
+
     def test_one_to_many_relationship(self):
         """Test one-to-many relationship conversion."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class User(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "users"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             username: Mapped[str] = mapped_column()
-            orders: Mapped[List["Order"]] = relationship(
-                back_populates="user",
-                info={"description": "User's orders"}
+            orders: Mapped[list["Order"]] = relationship(
+                back_populates="user", info={"description": "User's orders"}
             )
-        
+
         class Order(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "orders"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
             user: Mapped[User] = relationship(
-                back_populates="orders",
-                info={"description": "Order's user"}
+                back_populates="orders", info={"description": "Order's user"}
             )
-        
+
         # Convert to EnrichModel
         UserEnrichModel = User.__enrich_model__()
         fields = UserEnrichModel.model_fields
-        
+
         # Check that orders field exists and is a Relationship
         assert "orders" in fields
         assert isinstance(fields["orders"].default, Relationship)
         assert fields["orders"].default.description == "User's orders"
-        
+
         # Check the type annotation (should be List["OrderEnrichModel"])
         # The annotation will be a string forward reference
         assert "List" in str(fields["orders"].annotation)
         assert "OrderEnrichModel" in str(fields["orders"].annotation)
-    
+
     def test_many_to_one_relationship(self):
         """Test many-to-one relationship conversion."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class Order(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "orders"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
             user: Mapped["User"] = relationship(
                 info={"description": "Customer who placed the order"}
             )
-        
+
         class User(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "users"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             username: Mapped[str] = mapped_column()
-        
+
         OrderEnrichModel = Order.__enrich_model__()
         fields = OrderEnrichModel.model_fields
-        
+
         # Check that user field exists and is a Relationship
         assert "user" in fields
         assert isinstance(fields["user"].default, Relationship)
         assert fields["user"].default.description == "Customer who placed the order"
-        
+
         # Type should be just "UserEnrichModel" (not List)
         assert "UserEnrichModel" in str(fields["user"].annotation)
         assert "List" not in str(fields["user"].annotation)
-    
+
     def test_excluded_relationship(self):
         """Test that relationships marked with exclude=True are not included."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class User(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "users"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             username: Mapped[str] = mapped_column()
-            secret_orders: Mapped[List["Order"]] = relationship(
-                info={"exclude": True},
-                overlaps="public_orders"
+            secret_orders: Mapped[list["Order"]] = relationship(
+                info={"exclude": True}, overlaps="public_orders"
             )
-            public_orders: Mapped[List["Order"]] = relationship(
-                info={"description": "Public orders"},
-                overlaps="secret_orders"
+            public_orders: Mapped[list["Order"]] = relationship(
+                info={"description": "Public orders"}, overlaps="secret_orders"
             )
-        
+
         class Order(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "orders"
             id: Mapped[int] = mapped_column(primary_key=True)
             user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
-        
+
         UserEnrichModel = User.__enrich_model__()
         fields = UserEnrichModel.model_fields
-        
+
         # Check that excluded relationship is not included
         assert "secret_orders" not in fields
         assert "public_orders" in fields
-    
+
     def test_relationship_without_description(self):
         """Test relationship with no description gets a default one."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class User(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "users"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
-            posts: Mapped[List["Post"]] = relationship()
-        
+            posts: Mapped[list["Post"]] = relationship()
+
         class Post(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "posts"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
-        
+
         UserEnrichModel = User.__enrich_model__()
         fields = UserEnrichModel.model_fields
-        
+
         assert "posts" in fields
         assert isinstance(fields["posts"].default, Relationship)
         assert fields["posts"].default.description == "Relationship to PostEnrichModel"
@@ -322,93 +334,95 @@ class TestRelationships:
 
 class TestEdgeCases:
     """Test edge cases and error handling."""
-    
+
     def test_non_declarative_base_raises_error(self):
         """Test that using the mixin without DeclarativeBase raises an error."""
-        
+
         class NotSQLAlchemy(EnrichSQLAlchemyMixin):
             """This is not a SQLAlchemy model."""
+
             pass
-        
+
         with pytest.raises(TypeError) as exc_info:
             NotSQLAlchemy.__enrich_model__()
-        
+
         assert "must inherit from SQLAlchemy DeclarativeBase" in str(exc_info.value)
-    
+
     def test_model_with_no_docstring(self):
         """Test model without docstring gets a default one."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class NoDoc(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "no_doc"
             id: Mapped[int] = mapped_column(primary_key=True)
-        
+
         NoDocEnrichModel = NoDoc.__enrich_model__()
         assert NoDocEnrichModel.__doc__ == "NoDoc entity"
-    
+
     def test_async_attrs_compatibility(self):
         """Test that the mixin works with AsyncAttrs."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class AsyncUser(Base, AsyncAttrs, EnrichSQLAlchemyMixin):
             """Async user model."""
+
             __tablename__ = "async_users"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             username: Mapped[str] = mapped_column()
-        
+
         # Should work without issues
         AsyncUserEnrichModel = AsyncUser.__enrich_model__()
         assert issubclass(AsyncUserEnrichModel, EnrichModel)
         assert "id" in AsyncUserEnrichModel.model_fields
         assert "username" in AsyncUserEnrichModel.model_fields
-    
+
     def test_generated_model_name(self):
         """Test that generated EnrichModel has correct name."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class Customer(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "customers"
             id: Mapped[int] = mapped_column(primary_key=True)
-        
+
         CustomerEnrichModel = Customer.__enrich_model__()
         assert CustomerEnrichModel.__name__ == "CustomerEnrichModel"
-    
+
     def test_model_inheritance(self):
         """Test that the EnrichModel properly inherits from EnrichModel base."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class Product(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "products"
             id: Mapped[int] = mapped_column(primary_key=True)
             name: Mapped[str] = mapped_column()
-        
+
         ProductEnrichModel = Product.__enrich_model__()
-        
+
         # Should be a proper EnrichModel with all its methods
         assert hasattr(ProductEnrichModel, "model_dump")
         assert hasattr(ProductEnrichModel, "model_dump_json")
         assert hasattr(ProductEnrichModel, "relationship_fields")
         assert hasattr(ProductEnrichModel, "describe")
-    
+
     def test_sqlalchemy_model_reference_stored(self):
         """Test that reference to original SQLAlchemy model is stored."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class Order(Base, EnrichSQLAlchemyMixin):
             __tablename__ = "orders"
             id: Mapped[int] = mapped_column(primary_key=True)
-        
+
         OrderEnrichModel = Order.__enrich_model__()
         assert hasattr(OrderEnrichModel, "_sqlalchemy_model")
         assert OrderEnrichModel._sqlalchemy_model is Order
@@ -416,86 +430,90 @@ class TestEdgeCases:
 
 class TestComplexScenarios:
     """Test more complex real-world scenarios."""
-    
+
     def test_full_ecommerce_model(self):
         """Test a complete e-commerce model setup."""
-        
+
         class Base(DeclarativeBase):
             pass
-        
+
         class User(Base, EnrichSQLAlchemyMixin):
             """User account in the system."""
+
             __tablename__ = "users"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True, info={"description": "User ID"})
             email: Mapped[str] = mapped_column(unique=True, info={"description": "Email address"})
             username: Mapped[str] = mapped_column(info={"description": "Display name"})
             password_hash: Mapped[str] = mapped_column(info={"exclude": True})
-            created_at: Mapped[datetime] = mapped_column(info={"description": "Account creation time"})
-            is_active: Mapped[bool] = mapped_column(default=True, info={"description": "Account status"})
-            
-            orders: Mapped[List["Order"]] = relationship(
-                back_populates="user",
-                info={"description": "Orders placed by this user"}
+            created_at: Mapped[datetime] = mapped_column(
+                info={"description": "Account creation time"}
             )
-            reviews: Mapped[List["Review"]] = relationship(
-                back_populates="user",
-                info={"description": "Product reviews by this user"}
+            is_active: Mapped[bool] = mapped_column(
+                default=True, info={"description": "Account status"}
             )
-        
+
+            orders: Mapped[list["Order"]] = relationship(
+                back_populates="user", info={"description": "Orders placed by this user"}
+            )
+            reviews: Mapped[list["Review"]] = relationship(
+                back_populates="user", info={"description": "Product reviews by this user"}
+            )
+
         class Product(Base, EnrichSQLAlchemyMixin):
             """Product in the catalog."""
+
             __tablename__ = "products"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True, info={"description": "Product ID"})
             name: Mapped[str] = mapped_column(info={"description": "Product name"})
-            description: Mapped[Optional[str]] = mapped_column(
+            description: Mapped[str | None] = mapped_column(
                 Text, nullable=True, info={"description": "Product description"}
             )
             price: Mapped[float] = mapped_column(info={"description": "Product price"})
             stock_quantity: Mapped[int] = mapped_column(info={"description": "Available stock"})
-            
-            reviews: Mapped[List["Review"]] = relationship(
-                back_populates="product",
-                info={"description": "Customer reviews"}
+
+            reviews: Mapped[list["Review"]] = relationship(
+                back_populates="product", info={"description": "Customer reviews"}
             )
-        
+
         class Order(Base, EnrichSQLAlchemyMixin):
             """Customer order."""
+
             __tablename__ = "orders"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True, info={"description": "Order ID"})
             user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
             total_amount: Mapped[float] = mapped_column(info={"description": "Order total"})
             status: Mapped[str] = mapped_column(info={"description": "Order status"})
             created_at: Mapped[datetime] = mapped_column(info={"description": "Order date"})
-            
+
             user: Mapped[User] = relationship(
-                back_populates="orders",
-                info={"description": "Customer who placed the order"}
+                back_populates="orders", info={"description": "Customer who placed the order"}
             )
-        
+
         class Review(Base, EnrichSQLAlchemyMixin):
             """Product review."""
+
             __tablename__ = "reviews"
-            
+
             id: Mapped[int] = mapped_column(primary_key=True)
             user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
             product_id: Mapped[int] = mapped_column(ForeignKey("products.id"))
             rating: Mapped[int] = mapped_column(info={"description": "Rating 1-5"})
-            comment: Mapped[Optional[str]] = mapped_column(
+            comment: Mapped[str | None] = mapped_column(
                 Text, nullable=True, info={"description": "Review text"}
             )
-            
+
             user: Mapped[User] = relationship(back_populates="reviews")
             product: Mapped[Product] = relationship(back_populates="reviews")
-        
+
         # Convert all models
         UserEnrichModel = User.__enrich_model__()
         ProductEnrichModel = Product.__enrich_model__()
         OrderEnrichModel = Order.__enrich_model__()
         ReviewEnrichModel = Review.__enrich_model__()
-        
+
         # Verify User model
         user_fields = UserEnrichModel.model_fields
         assert "id" in user_fields
@@ -506,16 +524,16 @@ class TestComplexScenarios:
         assert "is_active" in user_fields
         assert "orders" in user_fields
         assert "reviews" in user_fields
-        
+
         # Verify relationships are properly typed
         assert isinstance(user_fields["orders"].default, Relationship)
         assert isinstance(user_fields["reviews"].default, Relationship)
-        
+
         # Verify Order model
         order_fields = OrderEnrichModel.model_fields
         assert "user" in order_fields
         assert isinstance(order_fields["user"].default, Relationship)
-        
+
         # Verify all models are proper EnrichModels
         for model in [UserEnrichModel, ProductEnrichModel, OrderEnrichModel, ReviewEnrichModel]:
             assert issubclass(model, EnrichModel)


### PR DESCRIPTION
## Summary
- add a `combine_lifespans` helper to merge multiple lifespans
- provide `sqlalchemy_lifespan` for standard SQLAlchemy setup
- use the new helper in the SQLAlchemy example
- document the helper in the example README

## Testing
- `ruff check .`
- `pyright` *(fails: Type of "get_version" is unknown, many others)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*

------
https://chatgpt.com/codex/tasks/task_e_684aef68a2f0832a8fe34280d13f8e3b