### PR TITLE
Fix SQLAlchemy tests by updating lockfile

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -47,6 +47,8 @@ filelock==3.18.0
     # via virtualenv
 ghp-import==2.1.0
     # via mkdocs
+greenlet==3.2.3
+    # via sqlalchemy
 griffe==1.7.3
     # via mkdocstrings-python
 h11==0.16.0
@@ -243,6 +245,10 @@ six==1.17.0
     # via python-dateutil
 sniffio==1.3.1
     # via anyio
+sqlalchemy==2.0.41
+    # via -r requirements-dev.txt
+sqlalchemy2-stubs==0.0.2a38
+    # via -r requirements-dev.txt
 sse-starlette==2.3.6
     # via mcp
 starlette==0.47.0
@@ -256,6 +262,8 @@ typing-extensions==4.14.0
     #   pydantic
     #   pydantic-core
     #   pyright
+    #   sqlalchemy
+    #   sqlalchemy2-stubs
     #   typing-inspection
 typing-inspection==0.4.1
     # via


### PR DESCRIPTION
## Summary
- update `uv.lock` so optional SQLAlchemy dependencies are installed

## Testing
- `make ci-setup`
- `make ci-test`


------
https://chatgpt.com/codex/tasks/task_e_684afdc833f0832aa64ae8f81b66981d