### PR TITLE
Limit Codecov upload to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: make ci-test
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.11'  # Only upload once
+        if: matrix.python-version == '3.11' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary
- only upload coverage to Codecov when the workflow runs on pushes to `main`

## Testing
- `pre-commit run --files .github/workflows/ci.yml`

------
https://chatgpt.com/codex/tasks/task_e_684b03f6b6dc832aa5bd12322f915ef9