### PR TITLE
Improve SQLAlchemy docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- SQLAlchemy integration with `EnrichSQLAlchemyMixin`,
+  `include_sqlalchemy_models` and `sqlalchemy_lifespan`
+- Automatic generation of resources and relationship resolvers from
+  SQLAlchemy models
+- Example project `examples/sqlalchemy_shop`
+
+### Changed
+- Development setup now uses `uv`
+
 ## [0.3.0] - 2025-06-11
 
 ### Added

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -468,4 +468,6 @@ All using only the features that enrichmcp actually provides!
 ## SQLAlchemy Auto-Generation
 
 The `examples/sqlalchemy_shop` project shows how `include_sqlalchemy_models`
-can generate entities and resolvers directly from SQLAlchemy models.
+can generate entities and resolvers directly from SQLAlchemy models. It works
+with any async database backend supported by SQLAlchemy (for example
+PostgreSQL with `asyncpg`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -191,6 +191,62 @@ async def get_user(user_id: int, ctx: EnrichContext) -> User:
 
 Context is automatically injected when you add a parameter typed as `EnrichContext`.
 
+## Using Existing SQLAlchemy Models
+
+Have a project full of SQLAlchemy models already? You can expose them as an MCP
+API in minutes:
+
+```python
+from sqlalchemy import ForeignKey
+from sqlalchemy.ext.asyncio import create_async_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from enrichmcp.sqlalchemy import (
+    EnrichSQLAlchemyMixin,
+    include_sqlalchemy_models,
+    sqlalchemy_lifespan,
+)
+
+engine = create_async_engine("postgresql+asyncpg://user:pass@localhost/db")
+
+
+class Base(DeclarativeBase, EnrichSQLAlchemyMixin):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    username: Mapped[str] = mapped_column(unique=True)
+    orders: Mapped[list["Order"]] = relationship(back_populates="user")
+
+
+class Order(Base):
+    __tablename__ = "orders"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    total: Mapped[float] = mapped_column()
+    user: Mapped[User] = relationship(back_populates="orders")
+
+
+class Product(Base):
+    __tablename__ = "products"
+
+    id: Mapped[int] = mapped_column(primary_key=True)
+    name: Mapped[str] = mapped_column()
+    price: Mapped[float] = mapped_column()
+
+
+lifespan = sqlalchemy_lifespan(Base, engine)
+app = EnrichMCP("My ORM API", lifespan=lifespan)
+include_sqlalchemy_models(app, Base)
+app.run()
+```
+
+`sqlalchemy_lifespan` works with any async engine and seeding data is optional.
+
 ## Next Steps
 
 - Explore more [Examples](examples.md) including the [SQLite example](https://github.com/featureform/enrichmcp/tree/main/examples/shop_api_sqlite)

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,6 +55,9 @@ async def get_customer(customer_id: int) -> Customer:
 app.run()
 ```
 
+Already using SQLAlchemy? See how to
+[turn existing models into an API](sqlalchemy.md) with just a few lines.
+
 ## Why enrichmcp?
 
 ### 🤖 Built for AI Agents


### PR DESCRIPTION
## Summary
- document SQLAlchemy `sqlalchemy_lifespan` cross-db support
- show how to convert existing SQLAlchemy models in README and docs
- emphasize SQLAlchemy example in docs
- add changelog entries for new SQLAlchemy features
- include real `User`, `Order`, and `Product` classes in docs

## Testing
- `make format`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684b0d631108832aa00d5abb965a1c53