### PR TITLE
Add API gateway shop example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Added shop_api_gateway example showing EnrichMCP as an API gateway
 ## [0.3.0] - 2025-06-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
 - Added shop_api_gateway example showing EnrichMCP as an API gateway
+
 ## [0.3.0] - 2025-06-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -285,8 +285,10 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 engine = create_async_engine("sqlite+aiosqlite:///shop.db")
 
+
 class Base(DeclarativeBase, EnrichSQLAlchemyMixin):
     pass
+
 
 lifespan = sqlalchemy_lifespan(Base, engine)
 app = EnrichMCP("Shop API", lifespan=lifespan)
@@ -296,6 +298,12 @@ include_sqlalchemy_models(app, Base)
 This generates `list_<model>` and `get_<model>` resources along with
 relationship resolvers based on your SQLAlchemy `relationship()`
 definitions.
+## Examples
+
+See the [examples directory](examples/README.md) for runnable projects, including:
+- `shop_api_sqlite` for a database-backed API
+- `shop_api_gateway` which wraps a FastAPI backend as an API gateway
+
 
 ## Development
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -469,3 +469,5 @@ All using only the features that enrichmcp actually provides!
 
 The `examples/sqlalchemy_shop` project shows how `include_sqlalchemy_models`
 can generate entities and resolvers directly from SQLAlchemy models.
+
+The `examples/shop_api_gateway` project shows how EnrichMCP can act as a simple API gateway in front of another FastAPI service.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -193,6 +193,6 @@ Context is automatically injected when you add a parameter typed as `EnrichConte
 
 ## Next Steps
 
-- Explore more [Examples](examples.md) including the [SQLite example](https://github.com/featureform/enrichmcp/tree/main/examples/shop_api_sqlite)
+- Explore more [Examples](examples.md) including the [SQLite example](https://github.com/featureform/enrichmcp/tree/main/examples/shop_api_sqlite) and the [API gateway example](https://github.com/featureform/enrichmcp/tree/main/examples/shop_api_gateway)
 - Read about [Core Concepts](concepts.md)
 - Check the [API Reference](api.md)

--- a/docs/sqlalchemy.md
+++ b/docs/sqlalchemy.md
@@ -14,8 +14,10 @@ from sqlalchemy.ext.asyncio import create_async_engine
 
 engine = create_async_engine("sqlite+aiosqlite:///shop.db")
 
+
 class Base(DeclarativeBase, EnrichSQLAlchemyMixin):
     pass
+
 
 # define SQLAlchemy models inheriting from Base
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -50,3 +50,19 @@ This example demonstrates:
 - Real database queries with relationships
 
 Both shop examples include the same core functionality but demonstrate different pagination strategies - page-based for in-memory data and cursor-based for database queries.
+
+## Shop API Gateway
+
+A version of the shop API that forwards all requests to a separate FastAPI
+backend. This demonstrates using EnrichMCP as a lightweight API gateway.
+
+To run this example:
+
+```bash
+cd shop_api_gateway
+uvicorn server:app --port 8001 &
+python app.py
+```
+
+Stop the background server when finished. The gateway listens on port 8000 and
+provides the same schema-driven interface as the other examples.

--- a/examples/shop_api_gateway/README.md
+++ b/examples/shop_api_gateway/README.md
@@ -1,0 +1,31 @@
+# Shop API Gateway Example
+
+This example demonstrates how to use **EnrichMCP** as a lightweight API gateway
+in front of an existing FastAPI service. The gateway exposes the same shop data
+model as other examples but forwards all requests to a separate backend running
+on `http://localhost:8001`.
+
+## Running the Example
+
+1. Start the backend FastAPI server:
+   ```bash
+   uvicorn server:app --port 8001
+   ```
+
+2. In another terminal, run the EnrichMCP gateway:
+   ```bash
+   python app.py
+   ```
+
+The gateway will be available on `http://localhost:8000` and acts as an
+agent-friendly layer over the backend service.
+
+## How It Works
+
+- `server.py` contains a normal FastAPI application with REST endpoints for
+  users, products and orders.
+- `app.py` defines the same data model using EnrichMCP. Each resolver makes
+  HTTP requests to `server.py`, effectively proxying calls.
+
+This pattern lets you keep your existing APIs while providing a schema-driven
+interface that AI agents can understand.

--- a/examples/shop_api_gateway/app.py
+++ b/examples/shop_api_gateway/app.py
@@ -1,0 +1,157 @@
+"""EnrichMCP API Gateway example.
+
+This example shows how EnrichMCP can sit in front of an existing FastAPI service
+and expose an agent-friendly API. All resolvers make HTTP requests to the
+backend, acting as a lightweight API gateway.
+"""
+
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime
+from typing import Any
+
+import httpx
+from pydantic import Field
+
+from enrichmcp import EnrichContext, EnrichMCP, EnrichModel, Relationship
+
+BACKEND_URL = "http://localhost:8001"
+
+
+@asynccontextmanager
+async def lifespan(app: EnrichMCP) -> AsyncIterator[dict[str, Any]]:
+    async with httpx.AsyncClient(base_url=BACKEND_URL) as client:
+        yield {"client": client}
+
+
+app = EnrichMCP(
+    title="Shop API Gateway",
+    description="EnrichMCP front-end for a FastAPI backend",
+    lifespan=lifespan,
+)
+
+
+@app.entity
+class User(EnrichModel):
+    """Customer account."""
+
+    id: int = Field(description="User ID")
+    username: str = Field(description="Username")
+    email: str = Field(description="Email")
+    full_name: str = Field(description="Full name")
+    created_at: datetime = Field(description="Account created")
+
+    orders: list["Order"] = Relationship(description="Orders for the user")
+
+
+@app.entity
+class Product(EnrichModel):
+    """Product for sale."""
+
+    id: int = Field(description="Product ID")
+    sku: str = Field(description="SKU")
+    name: str = Field(description="Name")
+    price: float = Field(description="Price in USD")
+
+
+@app.entity
+class Order(EnrichModel):
+    """Customer order."""
+
+    id: int = Field(description="Order ID")
+    order_number: str = Field(description="Order number")
+    user_id: int = Field(description="Owner user ID")
+    created_at: datetime = Field(description="Created timestamp")
+    status: str = Field(description="Status")
+    total_amount: float = Field(description="Total amount")
+
+    user: User = Relationship(description="User who placed the order")
+    products: list[Product] = Relationship(description="Products in the order")
+
+
+async def _client(ctx: EnrichContext) -> httpx.AsyncClient:
+    """Helper to get the shared HTTP client."""
+    return ctx.request_context.lifespan_context["client"]
+
+
+@app.resource
+async def list_users(ctx: EnrichContext) -> list[User]:
+    client = await _client(ctx)
+    resp = await client.get("/users")
+    resp.raise_for_status()
+    return [User(**u) for u in resp.json()]
+
+
+@app.resource
+async def get_user(user_id: int, ctx: EnrichContext) -> User:
+    client = await _client(ctx)
+    resp = await client.get(f"/users/{user_id}")
+    resp.raise_for_status()
+    return User(**resp.json())
+
+
+@app.resource
+async def list_products(ctx: EnrichContext) -> list[Product]:
+    client = await _client(ctx)
+    resp = await client.get("/products")
+    resp.raise_for_status()
+    return [Product(**p) for p in resp.json()]
+
+
+@app.resource
+async def get_product(product_id: int, ctx: EnrichContext) -> Product:
+    client = await _client(ctx)
+    resp = await client.get(f"/products/{product_id}")
+    resp.raise_for_status()
+    return Product(**resp.json())
+
+
+@app.resource
+async def list_orders(
+    user_id: int | None = None,
+    ctx: EnrichContext | None = None,
+) -> list[Order]:
+    if ctx is None:
+        raise RuntimeError("Context required")
+    client = await _client(ctx)
+    params = {"user_id": user_id} if user_id is not None else None
+    resp = await client.get("/orders", params=params)
+    resp.raise_for_status()
+    return [Order(**o) for o in resp.json()]
+
+
+@app.resource
+async def get_order(order_id: int, ctx: EnrichContext) -> Order:
+    client = await _client(ctx)
+    resp = await client.get(f"/orders/{order_id}")
+    resp.raise_for_status()
+    return Order(**resp.json())
+
+
+@User.orders.resolver
+async def get_orders_for_user(user_id: int, ctx: EnrichContext) -> list[Order]:
+    return await list_orders(user_id=user_id, ctx=ctx)
+
+
+@Order.user.resolver
+async def get_order_user(user_id: int, ctx: EnrichContext) -> User:
+    return await get_user(user_id=user_id, ctx=ctx)
+
+
+@Order.products.resolver
+async def get_order_products(order_id: int, ctx: EnrichContext) -> list[Product]:
+    client = await _client(ctx)
+    resp = await client.get(f"/orders/{order_id}")
+    resp.raise_for_status()
+    data = resp.json()
+    products = []
+    for pid in data.get("product_ids", []):
+        r = await client.get(f"/products/{pid}")
+        r.raise_for_status()
+        products.append(Product(**r.json()))
+    return products
+
+
+if __name__ == "__main__":
+    print("Starting Shop API Gateway...")
+    app.run(port=8000)

--- a/examples/shop_api_gateway/server.py
+++ b/examples/shop_api_gateway/server.py
@@ -1,0 +1,114 @@
+"""Simple FastAPI backend for the API gateway example."""
+
+from datetime import datetime
+
+from fastapi import FastAPI, HTTPException
+
+app = FastAPI(title="Shop Backend")
+
+USERS = [
+    {
+        "id": 1,
+        "username": "john_doe",
+        "email": "john@example.com",
+        "full_name": "John Doe",
+        "created_at": datetime(2022, 1, 15),
+    },
+    {
+        "id": 2,
+        "username": "jane_smith",
+        "email": "jane@example.com",
+        "full_name": "Jane Smith",
+        "created_at": datetime(2021, 6, 20),
+    },
+    {
+        "id": 3,
+        "username": "quick_buyer_2024",
+        "email": "tempmail@protonmail.com",
+        "full_name": "Alex Johnson",
+        "created_at": datetime(2024, 1, 5),
+    },
+]
+
+PRODUCTS = [
+    {"id": 101, "sku": "PHONE-001", "name": "Smartphone Pro", "price": 999.99},
+    {"id": 102, "sku": "LAPTOP-001", "name": "Business Laptop", "price": 1299.99},
+    {
+        "id": 103,
+        "sku": "HDPHONE-001",
+        "name": "Wireless Headphones",
+        "price": 299.99,
+    },
+]
+
+ORDERS = [
+    {
+        "id": 1001,
+        "order_number": "ORD-2023-1001",
+        "user_id": 1,
+        "created_at": datetime(2023, 10, 15, 14, 30),
+        "status": "delivered",
+        "total_amount": 329.98,
+        "product_ids": [103],
+    },
+    {
+        "id": 1002,
+        "order_number": "ORD-2023-1002",
+        "user_id": 2,
+        "created_at": datetime(2023, 11, 20, 11, 15),
+        "status": "delivered",
+        "total_amount": 1449.98,
+        "product_ids": [102],
+    },
+    {
+        "id": 1003,
+        "order_number": "ORD-2024-1003",
+        "user_id": 3,
+        "created_at": datetime(2024, 1, 6, 2, 45),
+        "status": "flagged",
+        "total_amount": 4299.99,
+        "product_ids": [101, 102, 103],
+    },
+]
+
+
+@app.get("/users")
+async def list_users():
+    return USERS
+
+
+@app.get("/users/{user_id}")
+async def get_user(user_id: int):
+    user = next((u for u in USERS if u["id"] == user_id), None)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user
+
+
+@app.get("/products")
+async def list_products():
+    return PRODUCTS
+
+
+@app.get("/products/{product_id}")
+async def get_product(product_id: int):
+    product = next((p for p in PRODUCTS if p["id"] == product_id), None)
+    if not product:
+        raise HTTPException(status_code=404, detail="Product not found")
+    return product
+
+
+@app.get("/orders")
+async def list_orders(user_id: int | None = None):
+    orders = ORDERS
+    if user_id is not None:
+        orders = [o for o in ORDERS if o["user_id"] == user_id]
+    return orders
+
+
+@app.get("/orders/{order_id}")
+async def get_order(order_id: int):
+    order = next((o for o in ORDERS if o["id"] == order_id), None)
+    if not order:
+        raise HTTPException(status_code=404, detail="Order not found")
+    return order


### PR DESCRIPTION
## Summary
- add new `shop_api_gateway` example acting as an API gateway for a FastAPI backend
- document the new example in README, docs and changelog
- mention new example in getting started docs

## Testing
- `make format`
- `make lint`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684b0dba3bf4832abc1667ecb46db027