### PR TITLE
Add SQLAlchemy example to examples README

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -50,3 +50,25 @@ This example demonstrates:
 - Real database queries with relationships
 
 Both shop examples include the same core functionality but demonstrate different pagination strategies - page-based for in-memory data and cursor-based for database queries.
+
+## SQLAlchemy Shop API
+
+A version of the shop example built with SQLAlchemy ORM models. All entities are
+declared using SQLAlchemy and registered through `include_sqlalchemy_models`,
+which automatically creates CRUD endpoints and relationship resolvers. The
+`sqlalchemy_lifespan` helper manages the async engine and seeds the SQLite
+database on first run.
+
+To run this example:
+
+```bash
+cd sqlalchemy_shop
+pip install -r requirements.txt
+python app.py
+```
+
+This example demonstrates:
+- Automatic conversion of SQLAlchemy models to EnrichMCP entities
+- Auto-generated CRUD resources and relationship resolvers
+- Async database access via SQLAlchemy
+- Database seeding and pagination using the generated endpoints


### PR DESCRIPTION
## Summary
- document SQLAlchemy shop example

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_684b10dfe834832aa4d71f2154989c74