### PR TITLE
Fix relationship serialization

### DIFF
--- a/src/enrichmcp/entity.py
+++ b/src/enrichmcp/entity.py
@@ -55,6 +55,15 @@ class EnrichModel(BaseModel):
         # If we get here, it's a type we don't handle
         raise TypeError(f"Cannot combine fields with exclude of type {type(original).__name__}.")
 
+    @override
+    def model_post_init(self, __context: Any) -> None:
+        """Remove relationship defaults after initialization."""
+        super().model_post_init(__context)
+
+        for field in self.__class__.relationship_fields():
+            if field in self.__dict__:
+                del self.__dict__[field]
+
     def describe(self) -> str:
         """
         Generate a human-readable description of this model.

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -179,3 +179,16 @@ def test_model_with_invalid_exclude_type():
 
     # Check that the error message is helpful
     assert "Cannot combine fields with exclude of type dict" in str(exc_info.value)
+
+
+def test_relationship_not_set_on_instance():
+    """Relationship defaults should be removed after initialization."""
+    user = User(id=1, name="John Doe", email="john@example.com")
+
+    # Relationship field should not be stored in the instance dict
+    assert "address" not in user.__dict__
+
+    # Attribute shouldn't exist on the instance
+    assert not hasattr(user, "address")
+    with pytest.raises(AttributeError):
+        _ = user.address


### PR DESCRIPTION
## Summary
- ensure relationship defaults are removed post-init so they don't serialize
- add test to verify instance cleanup

## Testing
- `pre-commit run --files src/enrichmcp/entity.py tests/test_entity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684efa772130832a9bbf0f13a1abeaab