### PR TITLE
Add optional db cleanup for SQLAlchemy examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,10 @@ class Order(Base):
     user: Mapped[User] = relationship(back_populates="orders")
 
 # That's it! Create your MCP app
-app = EnrichMCP("E-commerce Data", lifespan=sqlalchemy_lifespan(Base, engine))
+app = EnrichMCP(
+    "E-commerce Data",
+    lifespan=sqlalchemy_lifespan(Base, engine, cleanup_db_file=True),
+)
 include_sqlalchemy_models(app, Base)
 
 if __name__ == "__main__":

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -239,7 +239,7 @@ class Product(Base):
     price: Mapped[float] = mapped_column()
 
 
-lifespan = sqlalchemy_lifespan(Base, engine)
+lifespan = sqlalchemy_lifespan(Base, engine, cleanup_db_file=True)
 app = EnrichMCP("My ORM API", lifespan=lifespan)
 include_sqlalchemy_models(app, Base)
 app.run()

--- a/docs/sqlalchemy.md
+++ b/docs/sqlalchemy.md
@@ -67,3 +67,5 @@ Pagination parameters `page` and `page_size` are available on the generated
 `sqlalchemy_lifespan` automatically creates tables on startup and yields a
 `session_factory` that resolvers can use. Providing a `seed` function is
 optional and useful only for loading sample data during development or tests.
+If you are using a temporary SQLite file and want it removed on shutdown,
+pass `cleanup_db_file=True`.

--- a/examples/README.md
+++ b/examples/README.md
@@ -56,8 +56,9 @@ Both shop examples include the same core functionality but demonstrate different
 A version of the shop example built with SQLAlchemy ORM models. All entities are
 declared using SQLAlchemy and registered through `include_sqlalchemy_models`,
 which automatically creates CRUD endpoints and relationship resolvers. The
-`sqlalchemy_lifespan` helper manages the async engine and seeds the SQLite
-database on first run.
+`sqlalchemy_lifespan` helper manages the async engine, seeds the SQLite
+database on first run, and removes the file on shutdown when using
+`cleanup_db_file=True`.
 
 To run this example:
 

--- a/examples/sqlalchemy_shop/README.md
+++ b/examples/sqlalchemy_shop/README.md
@@ -47,6 +47,8 @@ The app will:
 
 The lifecycle is managed using the `sqlalchemy_lifespan` helper from
 `enrichmcp.sqlalchemy`, which provides a session factory to all resources.
+Passing `cleanup_db_file=True` removes the `shop.db` file when the app shuts
+down.
 
 ## Automatic Endpoints
 

--- a/examples/sqlalchemy_shop/app.py
+++ b/examples/sqlalchemy_shop/app.py
@@ -262,7 +262,8 @@ async def seed_database(session: AsyncSession) -> None:
 
 # Application instance will be created after defining the lifespan
 
-lifespan = sqlalchemy_lifespan(Base, engine, seed=seed_database)
+lifespan = sqlalchemy_lifespan(Base, engine, seed=seed_database, cleanup_db_file=True)
+
 
 app = EnrichMCP(
     title="Shop API (SQLAlchemy)",


### PR DESCRIPTION
## Summary
- add `cleanup_db_file` option to `sqlalchemy_lifespan`
- use the new option in the SQLAlchemy shop example
- document database cleanup in docs and READMEs

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_684efcdc5a60832a9518a3781f9ea6bd