### PR TITLE
Improve OpenAI chat example

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -4,9 +4,7 @@ This directory contains examples demonstrating how to use EnrichMCP.
 
 ## Hello World
 
-The simplest possible EnrichMCP application with a single resource that returns "Hello, World!".
-
-To run this example:
+The simplest EnrichMCP application with a single resource that returns "Hello, World!".
 
 ```bash
 cd hello_world
@@ -15,9 +13,7 @@ python app.py
 
 ## Shop API
 
-A comprehensive e-commerce shop API with multiple entities (users, orders, products) and relationships.
-
-To run this example:
+A comprehensive e-commerce API with multiple entities (users, orders and products).
 
 ```bash
 cd shop_api
@@ -33,9 +29,7 @@ This example demonstrates:
 
 ## Shop API with SQLite
 
-A database-backed version of the shop API using SQLite with real persistence.
-
-To run this example:
+A database-backed version of the shop API using SQLite.
 
 ```bash
 cd shop_api_sqlite
@@ -49,17 +43,11 @@ This example demonstrates:
 - Dynamic sample data generation
 - Real database queries with relationships
 
-Both shop examples include the same core functionality but demonstrate different pagination strategies - page-based for in-memory data and cursor-based for database queries.
+Both shop examples provide the same functionality but showcase different pagination strategies.
 
 ## SQLAlchemy Shop API
 
-A version of the shop example built with SQLAlchemy ORM models. All entities are
-declared using SQLAlchemy and registered through `include_sqlalchemy_models`,
-which automatically creates CRUD endpoints and relationship resolvers. The
-`sqlalchemy_lifespan` helper manages the async engine and seeds the SQLite
-database on first run.
-
-To run this example:
+A variant that uses SQLAlchemy models. All entities are declared using SQLAlchemy and registered through `include_sqlalchemy_models`.
 
 ```bash
 cd sqlalchemy_shop
@@ -75,8 +63,7 @@ This example demonstrates:
 
 ## Shop API Gateway
 
-A version of the shop API that forwards all requests to a separate FastAPI
-backend. This demonstrates using EnrichMCP as a lightweight API gateway.
+A gateway example that forwards all requests to a FastAPI backend.
 
 ```bash
 cd shop_api_gateway
@@ -84,5 +71,23 @@ uvicorn server:app --port 8001 &
 python app.py
 ```
 
-Stop the background server when finished. The gateway listens on port 8000 and
-provides the same schema-driven interface as the other examples.
+Stop the background server when finished. The gateway listens on port 8000 and provides the same schema-driven interface as the other examples.
+
+## OpenAI MCP Chat Agent
+
+An interactive command-line chat agent that connects to one of the examples
+via MCP and lets you talk to it with either OpenAI or a local Ollama model.
+
+```bash
+cd openai_chat_agent
+# copy the sample environment and optionally set OPENAI_API_KEY
+cp .env.example .env
+python app.py
+```
+
+If `OPENAI_API_KEY` is not set the agent defaults to a local Ollama model defined
+by `OLLAMA_MODEL` (defaults to `llama3`).
+The included configuration starts the `hello_world` example using the MCP
+stdio connector so everything runs locally.
+This example demonstrates how to use `MCPAgent` with built-in conversation
+memory for chatting with your MCP data.

--- a/examples/openai_chat_agent/.env.example
+++ b/examples/openai_chat_agent/.env.example
@@ -1,0 +1,3 @@
+# Copy this file to .env and set your preferred model
+# OPENAI_API_KEY=sk-...
+# OLLAMA_MODEL=llama3

--- a/examples/openai_chat_agent/app.py
+++ b/examples/openai_chat_agent/app.py
@@ -1,0 +1,79 @@
+"""Interactive OpenAI agent using MCPAgent.
+
+This script connects an OpenAI chat model to an MCP server and keeps
+conversation context using the agent's built-in memory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from dotenv import load_dotenv
+from langchain_community.chat_models import ChatOllama
+from langchain_openai import ChatOpenAI
+from mcp_use import MCPAgent, MCPClient
+
+SYSTEM_MESSAGE = "You are a helpful assistant that talks to the user and uses tools via MCP."
+
+
+async def run_memory_chat() -> None:
+    """Run an interactive chat session with conversation memory enabled."""
+    load_dotenv()
+    config_file = os.path.join(os.path.dirname(__file__), "config.json")
+
+    print("Initializing chat...")
+    client = MCPClient.from_config_file(config_file)
+
+    openai_key = os.getenv("OPENAI_API_KEY")
+    ollama_model = os.getenv("OLLAMA_MODEL", "llama3")
+
+    llm = ChatOpenAI(model="gpt-4o") if openai_key else ChatOllama(model=ollama_model)
+
+    agent = MCPAgent(
+        llm=llm,
+        client=client,
+        max_steps=15,
+        memory_enabled=True,
+        system_prompt=SYSTEM_MESSAGE,
+    )
+
+    print("\n===== Interactive MCP Chat =====")
+    print("Type 'exit' or 'quit' to end the conversation")
+    print("Type 'clear' to clear conversation history")
+    print("Type 'history' to display the conversation so far")
+    print("=================================\n")
+
+    try:
+        while True:
+            user_input = input("\nYou: ")
+            command = user_input.lower()
+
+            if command in ("exit", "quit"):
+                print("Ending conversation...")
+                break
+
+            if command == "clear":
+                agent.clear_conversation_history()
+                print("Conversation history cleared.")
+                continue
+
+            if command == "history":
+                for msg in agent.conversation_history:
+                    role = msg.get("role", "assistant").capitalize()
+                    print(f"{role}: {msg['content']}")
+                continue
+
+            print("\nAssistant: ", end="", flush=True)
+            try:
+                response = await agent.run(user_input)
+                print(response)
+            except Exception as exc:
+                print(f"\nError: {exc}")
+    finally:
+        if client and client.sessions:
+            await client.close_all_sessions()
+
+
+if __name__ == "__main__":
+    asyncio.run(run_memory_chat())

--- a/examples/openai_chat_agent/config.json
+++ b/examples/openai_chat_agent/config.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "hello_world": {
+      "command": "python",
+      "args": ["../hello_world/app.py"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- expand instructions and mention stdio config in the examples README
- default to a local model when OPENAI_API_KEY isn't set
- rename `mcp_server.json` to `config.json` and wire up the hello_world example

## Testing
- `pytest -q`
- Ran `openai_chat_agent/app.py` manually with default config

------
https://chatgpt.com/codex/tasks/task_e_684ef9d5eafc832a8f6e118d6851fef6