### PR TITLE
Improve coverage excludes for type checking imports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -6,7 +6,11 @@ relative_files = True
 exclude_lines =
     pragma: no cover
     def __repr__
+    raise AssertionError
     raise NotImplementedError
-    if __name__ == .__main__.:
+    if __name__ == .__main__.
     pass
+    if TYPE_CHECKING:
+    Protocol
+    @abstractmethod
     raise ImportError

--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -33,7 +33,7 @@ from .relationship import (
     Relationship,
 )
 
-if TYPE_CHECKING:  # pragma: no cover - optional dependency
+if TYPE_CHECKING:
     from .sqlalchemy import EnrichSQLAlchemyMixin, sqlalchemy_lifespan
 
 # Optional SQLAlchemy integration

--- a/src/enrichmcp/sqlalchemy/lifecycle.py
+++ b/src/enrichmcp/sqlalchemy/lifecycle.py
@@ -14,7 +14,7 @@ from sqlalchemy.ext.asyncio import (
 
 from enrichmcp.app import EnrichMCP
 
-if TYPE_CHECKING:  # pragma: no cover - type checking import
+if TYPE_CHECKING:
     from sqlalchemy.orm import (
         DeclarativeBase,  # pyright: ignore[reportMissingImports,reportAttributeAccessIssue]
     )


### PR DESCRIPTION
## Summary
- ignore `TYPE_CHECKING` blocks in coverage
- mark optional imports as excluded
- drop explicit pragmas inside `TYPE_CHECKING` blocks

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685094dd1a04832aac1eeaec479d130d