### PR TITLE
Add Mutability API

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,30 @@ class Order(EnrichModel):
     status: Literal["pending", "shipped", "delivered"]
 ```
 
+### ✏️ Mutability & CRUD
+
+Fields are immutable by default. Mark them as mutable and use
+auto-generated patch models for updates:
+
+```python
+@app.entity
+class Customer(EnrichModel):
+    id: int = Field(description="ID")
+    email: str = Field(mutable=True, description="Email")
+
+@app.create
+async def create_customer(email: str) -> Customer:
+    ...
+
+@app.update
+async def update_customer(cid: int, patch: Customer.PatchModel) -> Customer:
+    ...
+
+@app.delete
+async def delete_customer(cid: int) -> bool:
+    ...
+```
+
 ### 📄 Pagination Built-in
 
 Handle large datasets elegantly:

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -63,6 +63,37 @@ async def list_users() -> list[User]:
     return await fetch_all_users()
 ```
 
+### `create(func=None, *, name=None, description=None)`
+
+Register an entity creation operation. Works like `@app.resource` but
+indicates a create action.
+
+```python
+@app.create
+async def create_user(email: str) -> User:
+    ...
+```
+
+### `update(func=None, *, name=None, description=None)`
+
+Register an entity update using a patch model containing mutable fields.
+
+```python
+@app.update
+async def update_user(uid: int, patch: User.PatchModel) -> User:
+    ...
+```
+
+### `delete(func=None, *, name=None, description=None)`
+
+Register an entity deletion operation.
+
+```python
+@app.delete
+async def delete_user(uid: int) -> bool:
+    ...
+```
+
 ### `run(**options)`
 
 Start the MCP server.

--- a/docs/api/entity.md
+++ b/docs/api/entity.md
@@ -155,6 +155,19 @@ tags: list[str] = Field(description="List of tags", default_factory=list)
 metadata: dict[str, Any] = Field(description="Arbitrary metadata", default_factory=dict)
 ```
 
+### Mutable Fields
+
+Fields are immutable unless `mutable=True`:
+
+```python
+@app.entity
+class Customer(EnrichModel):
+    id: int = Field(description="ID")
+    email: str = Field(mutable=True, description="Email")
+
+    # Customer.PatchModel is generated automatically
+```
+
 ## Serialization
 
 EnrichModel automatically excludes relationship fields when serializing:

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,6 +83,7 @@ Focus on your data model, not protocol details:
 - **Automatic Tool Generation**: Decorators handle all MCP setup
 - **Smart Defaults**: Sensible conventions out of the box
 - **Clean APIs**: Intuitive patterns inspired by GraphQL and ORMs
+- **Mutable Fields**: Opt‑in mutability with auto-generated patch models
 
 ## How It Works
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -81,6 +81,15 @@ python app.py
 Stop the background server when finished. The gateway listens on port 8000 and
 provides the same schema-driven interface as the other examples.
 
+## Mutable CRUD
+
+A minimal API showcasing mutable fields and the new CRUD decorators.
+
+```bash
+cd mutable_crud
+python app.py
+```
+
 Stop the background server when finished. The gateway listens on port 8000 and provides the same schema-driven interface as the other examples.
 
 ## OpenAI MCP Chat Agent

--- a/examples/mutable_crud/README.md
+++ b/examples/mutable_crud/README.md
@@ -1,0 +1,10 @@
+# Mutable CRUD Example
+
+A minimal API demonstrating the new mutability features and CRUD decorators.
+
+```bash
+cd mutable_crud
+python app.py
+```
+
+Use the generated tools to create, update and delete customers.

--- a/examples/mutable_crud/app.py
+++ b/examples/mutable_crud/app.py
@@ -1,0 +1,56 @@
+from datetime import datetime
+
+from pydantic import Field
+
+from enrichmcp import EnrichMCP, EnrichModel
+
+app = EnrichMCP(
+    title="Customer CRUD API",
+    description="Demonstrates mutability and CRUD decorators",
+)
+
+
+@app.entity
+class Customer(EnrichModel):
+    """Simple customer record."""
+
+    id: int = Field(description="Customer ID")
+    created_at: datetime = Field(default_factory=datetime.utcnow, description="Creation timestamp")
+    email: str = Field(mutable=True, description="Email address")
+    tier: str = Field(mutable=True, description="Subscription tier", default="free")
+
+
+CUSTOMERS: dict[int, Customer] = {}
+
+
+@app.create
+async def create_customer(email: str, tier: str = "free") -> Customer:
+    """Create a new customer."""
+    cid = len(CUSTOMERS) + 1
+    customer = Customer(id=cid, email=email, tier=tier)
+    CUSTOMERS[cid] = customer
+    return customer
+
+
+@app.update
+async def update_customer(customer_id: int, patch: Customer.PatchModel) -> Customer:
+    """Update an existing customer."""
+    customer = CUSTOMERS[customer_id]
+    data = patch.dict(exclude_unset=True)
+    updated = customer.copy(update=data)
+    CUSTOMERS[customer_id] = updated
+    return updated
+
+
+@app.delete
+async def delete_customer(customer_id: int) -> bool:
+    """Delete a customer."""
+    return CUSTOMERS.pop(customer_id, None) is not None
+
+
+def main() -> None:
+    app.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -1,0 +1,60 @@
+import pytest
+from pydantic import Field
+
+from enrichmcp import EnrichMCP, EnrichModel
+
+
+@pytest.mark.asyncio
+async def test_patch_model_generation_and_mutable_fields():
+    app = EnrichMCP("Test API", description="desc")
+
+    @app.entity
+    class Customer(EnrichModel):
+        """Customer entity."""
+
+        id: int = Field(description="id")
+        email: str = Field(description="email", mutable=True)
+        status: str = Field(description="status", mutable=True)
+
+    # mutable fields detected
+    assert Customer.mutable_fields() == {"email", "status"}
+    assert hasattr(Customer, "PatchModel")
+    patch_fields = set(Customer.PatchModel.model_fields.keys())
+    assert patch_fields == {"email", "status"}
+
+
+@pytest.mark.asyncio
+async def test_crud_decorators_register_resources():
+    app = EnrichMCP("API", description="desc")
+
+    @app.entity
+    class Item(EnrichModel):
+        """Item entity."""
+
+        id: int = Field(description="id")
+        name: str = Field(description="name", mutable=True)
+
+    @app.create
+    async def create_item(name: str) -> Item:
+        """Create item."""
+        return Item(id=1, name=name)
+
+    @app.update
+    async def update_item(item_id: int, patch: Item.PatchModel) -> Item:
+        """Update item."""
+        return Item(id=item_id, name=patch.name or "n")
+
+    @app.delete
+    async def delete_item(item_id: int) -> bool:
+        """Delete item."""
+        return True
+
+    assert "create_item" in app.resources
+    assert "update_item" in app.resources
+    assert "delete_item" in app.resources
+
+    item = await create_item(name="x")
+    assert item.name == "x"
+    item = await update_item(1, Item.PatchModel(name="y"))
+    assert item.name == "y"
+    assert await delete_item(1) is True


### PR DESCRIPTION
## Summary
- add CRUD decorators and patch model generation
- mark fields as mutable and expose patches in docs
- document mutability features in README and docs
- test mutability functions
- support `mutable=True` field flag and add CRUD example

## Testing
- `pytest tests/test_mutability.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68542c008234832abb0f6ebe1519fc5e