### PR TITLE
Enable Python 3.13 tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4
@@ -27,7 +27,7 @@ jobs:
           cache-dependency-path: |
             requirements.txt
             requirements-dev.txt
-            
+
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 


### PR DESCRIPTION
## Summary
- add Python 3.13 to the GitHub Actions matrix

## Testing
- `make ci-test`


------
https://chatgpt.com/codex/tasks/task_e_685438885fcc832a987646f6f541b1e8