### PR TITLE
Rename resource decorator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2025-06-19
+
+### Changed
+- Renamed `app.resource` decorator to `app.retrieve`; `app.resource` remains available as a deprecated alias.
+
 ## [0.4.1] - 2025-06-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ class Order(EnrichModel):
     customer: Customer = Relationship(description="Customer who placed this order")
 
 # Define how to fetch data
-@app.resource
+@app.retrieve
 async def get_customer(customer_id: int) -> Customer:
     """Fetch customer from CRM API."""
     response = await http.get(f"/api/customers/{customer_id}")
@@ -165,7 +165,7 @@ class Segment(EnrichModel):
     users: list[User] = Relationship(description="Users in this segment")
 
 # Complex resource with business logic
-@app.resource
+@app.retrieve
 async def find_high_value_at_risk_users(
     lifetime_value_min: Decimal = 1000,
     churn_risk_min: float = 0.7,
@@ -245,7 +245,7 @@ Handle large datasets elegantly:
 ```python
 from enrichmcp import PageResult
 
-@app.resource
+@app.retrieve
 async def list_orders(
     page: int = 1,
     page_size: int = 50
@@ -266,7 +266,7 @@ See the [Pagination Guide](https://featureform.github.io/enrichmcp/pagination) f
 Pass auth, database connections, or any context:
 
 ```python
-@app.resource
+@app.retrieve
 async def get_user_profile(user_id: int, context: EnrichContext) -> UserProfile:
     # Access context provided by MCP client
     auth_user = context.get("authenticated_user_id")

--- a/docs/api.md
+++ b/docs/api.md
@@ -72,7 +72,7 @@ async def get_user_orders(user_id: int) -> list["Order"]:
 Resources are the entry points for AI agents:
 
 ```python
-@app.resource
+@app.retrieve
 async def list_users() -> list[User]:
     """List all users in the system."""
     return fetch_all_users()

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -46,9 +46,10 @@ class User(EnrichModel):
     name: str = Field(description="Username")
 ```
 
-### `resource(func=None, *, name=None, description=None)`
+### `retrieve(func=None, *, name=None, description=None)`
 
-Decorator to register a function as an MCP resource.
+Register a function as an MCP resource. The older ``resource`` decorator
+is still available but deprecated. Switch to ``retrieve`` for new code.
 
 **Parameters:**
 - `func`: The function (when used without parentheses)
@@ -57,7 +58,7 @@ Decorator to register a function as an MCP resource.
 
 **Example:**
 ```python
-@app.resource
+@app.retrieve
 async def list_users() -> list[User]:
     """List all users in the system."""
     return await fetch_all_users()
@@ -183,7 +184,7 @@ async def get_book_author(book_id: int) -> Author:
 
 
 # Define resources
-@app.resource
+@app.retrieve
 async def list_authors() -> list[Author]:
     """List all authors."""
     # Implementation here

--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -45,7 +45,7 @@ class MyContext(EnrichContext):
 
 
 # Use in resources
-@app.resource
+@app.retrieve
 async def get_data(context: MyContext) -> dict:
     # Use your custom context
     return await context.db.fetch_data()

--- a/docs/api/errors.md
+++ b/docs/api/errors.md
@@ -33,7 +33,7 @@ except ValidationError as e:
 Use Python's standard exceptions:
 
 ```python
-@app.resource
+@app.retrieve
 async def get_user(user_id: int) -> User:
     user = find_user(user_id)
     if not user:

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -149,7 +149,7 @@ async def get_orders(customer_id: int, limit: int = 10, offset: int = 0) -> list
 Resources are the entry points for AI agents:
 
 ```python
-@app.resource
+@app.retrieve
 async def get_customer(customer_id: int) -> Customer:
     """Retrieve a customer by ID.
 
@@ -162,7 +162,7 @@ async def get_customer(customer_id: int) -> Customer:
     return customer
 
 
-@app.resource
+@app.retrieve
 async def search_customers(query: str, status: str | None = None) -> list[Customer]:
     """Search for customers by name or email.
 
@@ -194,7 +194,7 @@ class AppContext(EnrichContext):
     user: User | None = None
 
 
-@app.resource
+@app.retrieve
 async def get_customer(customer_id: int, context: AppContext) -> Customer:
     """Get customer using context."""
     # Check cache first
@@ -236,7 +236,7 @@ enrichmcp leverages Pydantic for comprehensive validation:
 
 ```python
 # This automatically validates inputs
-@app.resource
+@app.retrieve
 async def create_customer(
     email: EmailStr,  # Validates email format
     age: int = Field(ge=18, le=150),  # Range validation
@@ -255,7 +255,7 @@ EnrichMCP extends FastMCP's context system to provide automatic injection of log
 Any resource or resolver can receive context by adding a parameter typed as `EnrichContext`:
 
 ```python
-@app.resource
+@app.retrieve
 async def my_resource(param: str, ctx: EnrichContext) -> Result:
     # Context is automatically injected
     await ctx.info("Processing request")
@@ -325,7 +325,7 @@ Use semantic errors that AI agents understand:
 from enrichmcp.errors import NotFoundError, ValidationError, AuthorizationError
 
 
-@app.resource
+@app.retrieve
 async def get_order(order_id: int, context: AppContext) -> Order:
     order = await context.db.get_order(order_id)
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -110,13 +110,13 @@ async def get_book_author(book_id: int) -> "Author":
 
 
 # Define root resources
-@app.resource
+@app.retrieve
 async def list_authors() -> list[Author]:
     """List all authors in the catalog."""
     return [Author(**author_data) for author_data in AUTHORS]
 
 
-@app.resource
+@app.retrieve
 async def get_author(author_id: int) -> Author:
     """Get a specific author by ID."""
     author_data = next((a for a in AUTHORS if a["id"] == author_id), None)
@@ -126,13 +126,13 @@ async def get_author(author_id: int) -> Author:
     return Author(id=-1, name="Not Found", bio="Author not found", birth_date=date(1900, 1, 1))
 
 
-@app.resource
+@app.retrieve
 async def list_books() -> list[Book]:
     """List all books in the catalog."""
     return [Book(**book_data) for book_data in BOOKS]
 
 
-@app.resource
+@app.retrieve
 async def search_books(title_contains: str) -> list[Book]:
     """Search for books by title."""
     matching_books = [book for book in BOOKS if title_contains.lower() in book["title"].lower()]
@@ -283,13 +283,13 @@ async def get_task_project(task_id: int) -> "Project":
 
 
 # Resources
-@app.resource
+@app.retrieve
 async def list_projects() -> list[Project]:
     """List all projects."""
     return [Project(**project_data) for project_data in PROJECTS]
 
 
-@app.resource
+@app.retrieve
 async def list_tasks(status: Status | None = None, priority: Priority | None = None) -> list[Task]:
     """List tasks with optional filtering."""
     filtered_tasks = TASKS
@@ -303,7 +303,7 @@ async def list_tasks(status: Status | None = None, priority: Priority | None = N
     return [Task(**task_data) for task_data in filtered_tasks]
 
 
-@app.resource
+@app.retrieve
 async def get_project_summary(project_id: int) -> dict:
     """Get summary statistics for a project."""
     project_tasks = [t for t in TASKS if t["project_id"] == project_id]
@@ -421,13 +421,13 @@ async def get_ingredient_recipes(ingredient_id: int) -> list["Recipe"]:
 
 
 # Resources
-@app.resource
+@app.retrieve
 async def list_recipes() -> list[Recipe]:
     """List all recipes."""
     return [Recipe(**recipe_data) for recipe_data in RECIPES]
 
 
-@app.resource
+@app.retrieve
 async def search_recipes_by_ingredient(ingredient_name: str) -> list[Recipe]:
     """Find recipes containing a specific ingredient."""
     # Find ingredient
@@ -442,7 +442,7 @@ async def search_recipes_by_ingredient(ingredient_name: str) -> list[Recipe]:
     return await get_ingredient_recipes(ingredient["id"])
 
 
-@app.resource
+@app.retrieve
 async def get_quick_recipes(max_time: int = 30) -> list[Recipe]:
     """Get recipes that can be made quickly."""
     quick_recipes = [
@@ -459,7 +459,7 @@ These examples demonstrate:
 - Basic entity definition with `@app.entity`
 - Relationship definition with `Relationship()`
 - Resolver implementation with `@Entity.field.resolver`
-- Resource creation with `@app.resource`
+- Resource creation with `@app.retrieve`
 - Simple in-memory data storage
 - Filtering and searching patterns
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -126,7 +126,7 @@ async def get_book_author(book_id: int) -> Author:
 
 
 # Define root resources
-@app.resource
+@app.retrieve
 async def list_books() -> list[Book]:
     """List all books in the catalog."""
     return [
@@ -140,7 +140,7 @@ async def list_books() -> list[Book]:
     ]
 
 
-@app.resource
+@app.retrieve
 async def get_author(author_id: int) -> Author:
     """Get a specific author by ID."""
     return Author(id=author_id, name="Jane Doe", bio="Bestselling author")
@@ -175,7 +175,7 @@ app = EnrichMCP("My API", "Description", lifespan=lifespan)
 
 
 # Use context in resources and resolvers
-@app.resource
+@app.retrieve
 async def get_user(user_id: int, ctx: EnrichContext) -> User:
     # Logging
     await ctx.info(f"Fetching user {user_id}")

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,7 +45,7 @@ async def get_customer_orders(customer_id: int) -> list[Order]:
 
 
 # Create entry points for AI
-@app.resource
+@app.retrieve
 async def get_customer(customer_id: int) -> Customer:
     """Get a customer by ID."""
     return await db.get_customer(customer_id)

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -20,7 +20,7 @@ class User(EnrichModel):
 
 
 # Page-based pagination
-@app.resource
+@app.retrieve
 async def list_users(page: int = 1, page_size: int = 50) -> PageResult[User]:
     """List users with page-based pagination."""
     users, total = await db.get_users_page(page, page_size)
@@ -34,7 +34,7 @@ async def list_users(page: int = 1, page_size: int = 50) -> PageResult[User]:
 
 
 # Cursor-based pagination
-@app.resource
+@app.retrieve
 async def stream_users(cursor: str | None = None, limit: int = 50) -> CursorResult[User]:
     """Stream users with cursor-based pagination."""
     users, next_cursor = await db.get_users_cursor(cursor, limit)
@@ -55,7 +55,7 @@ Page-based pagination uses page numbers and is ideal for:
 from enrichmcp import PageResult, PaginationParams
 
 
-@app.resource
+@app.retrieve
 async def list_orders(
     page: int = 1, page_size: int = 25, status: str | None = None
 ) -> PageResult[Order]:
@@ -101,7 +101,7 @@ Cursor-based pagination uses cursors and is ideal for:
 from enrichmcp import CursorResult, CursorParams
 
 
-@app.resource
+@app.retrieve
 async def stream_notifications(
     cursor: str | None = None, limit: int = 20
 ) -> CursorResult[Notification]:
@@ -139,7 +139,7 @@ Use `PaginationParams` for consistent page-based pagination parameters:
 from enrichmcp import PaginationParams
 
 
-@app.resource
+@app.retrieve
 async def search_users(query: str, pagination: PaginationParams | None = None) -> PageResult[User]:
     """Search users with pagination helper."""
     if pagination is None:
@@ -174,7 +174,7 @@ Use `CursorParams` for consistent cursor-based pagination:
 from enrichmcp import CursorParams
 
 
-@app.resource
+@app.retrieve
 async def list_events(
     event_type: str | None = None, cursor_params: CursorParams | None = None
 ) -> CursorResult[Event]:
@@ -366,7 +366,7 @@ else:
 ### 4. Add Filtering and Sorting
 
 ```python
-@app.resource
+@app.retrieve
 async def search_orders(
     status: str | None = None,
     user_id: int | None = None,
@@ -470,13 +470,13 @@ async def test_cursor_pagination():
 
 ```python
 # Before: Returns all items
-@app.resource
+@app.retrieve
 async def list_users() -> list[User]:
     return await db.get_all_users()
 
 
 # After: Add pagination parameters
-@app.resource
+@app.retrieve
 async def list_users(page: int = 1, page_size: int = 50) -> PageResult[User]:
     users, total = await db.get_users_page(page, page_size)
     return PageResult.create(

--- a/examples/hello_world/app.py
+++ b/examples/hello_world/app.py
@@ -13,7 +13,7 @@ def main():
     app = EnrichMCP(title="Hello World API", description="A simple API that says hello!")
 
     # Define a hello world resource
-    @app.resource(description="Say hello to the world")
+    @app.retrieve(description="Say hello to the world")
     async def hello_world() -> dict:
         """
         A simple resource that returns a hello world message.

--- a/examples/shop_api/app.py
+++ b/examples/shop_api/app.py
@@ -433,7 +433,7 @@ async def by_order_id_products(order_id: int) -> list[Product]:
 
 
 # Define root resources
-@app.resource
+@app.retrieve
 async def list_users() -> list[User]:
     """List all users in the system.
 
@@ -447,7 +447,7 @@ async def list_users() -> list[User]:
     return [User(**user_data) for user_data in USERS]
 
 
-@app.resource
+@app.retrieve
 async def get_user(user_id: int) -> User:
     """Get a specific user by ID.
 
@@ -481,7 +481,7 @@ async def get_user(user_id: int) -> User:
     return User(**user_data)
 
 
-@app.resource
+@app.retrieve
 async def list_products() -> list[Product]:
     """List all products in the catalog.
 
@@ -495,7 +495,7 @@ async def list_products() -> list[Product]:
     return [Product(**product_data) for product_data in PRODUCTS]
 
 
-@app.resource
+@app.retrieve
 async def list_orders(
     status: str | None = None, page: int = 1, page_size: int = 10
 ) -> PageResult[Order]:

--- a/examples/shop_api_gateway/app.py
+++ b/examples/shop_api_gateway/app.py
@@ -74,7 +74,7 @@ async def _client(ctx: EnrichContext) -> httpx.AsyncClient:
     return ctx.request_context.lifespan_context["client"]
 
 
-@app.resource
+@app.retrieve
 async def list_users(ctx: EnrichContext) -> list[User]:
     """Fetch all users from the backend service."""
     client = await _client(ctx)
@@ -83,7 +83,7 @@ async def list_users(ctx: EnrichContext) -> list[User]:
     return [User(**u) for u in resp.json()]
 
 
-@app.resource
+@app.retrieve
 async def get_user(user_id: int, ctx: EnrichContext) -> User:
     """Return a single user by ID."""
     client = await _client(ctx)
@@ -92,7 +92,7 @@ async def get_user(user_id: int, ctx: EnrichContext) -> User:
     return User(**resp.json())
 
 
-@app.resource
+@app.retrieve
 async def list_products(ctx: EnrichContext) -> list[Product]:
     """Retrieve all products available for sale."""
     client = await _client(ctx)
@@ -101,7 +101,7 @@ async def list_products(ctx: EnrichContext) -> list[Product]:
     return [Product(**p) for p in resp.json()]
 
 
-@app.resource
+@app.retrieve
 async def get_product(product_id: int, ctx: EnrichContext) -> Product:
     """Get a single product by ID."""
     client = await _client(ctx)
@@ -110,7 +110,7 @@ async def get_product(product_id: int, ctx: EnrichContext) -> Product:
     return Product(**resp.json())
 
 
-@app.resource
+@app.retrieve
 async def list_orders(
     user_id: int | None = None,
     ctx: EnrichContext | None = None,
@@ -125,7 +125,7 @@ async def list_orders(
     return [Order(**o) for o in resp.json()]
 
 
-@app.resource
+@app.retrieve
 async def get_order(order_id: int, ctx: EnrichContext) -> Order:
     """Retrieve a specific order."""
     client = await _client(ctx)

--- a/examples/shop_api_sqlite/README.md
+++ b/examples/shop_api_sqlite/README.md
@@ -52,7 +52,7 @@ async def lifespan(app: EnrichMCP) -> AsyncIterator[dict[str, Any]]:
 Resources and resolvers receive context automatically when they have a parameter typed as `EnrichContext`:
 
 ```python
-@app.resource
+@app.retrieve
 async def get_user(user_id: int, ctx: EnrichContext) -> User:
     # Access database from lifespan context
     db = ctx.request_context.lifespan_context["db"]

--- a/examples/shop_api_sqlite/app.py
+++ b/examples/shop_api_sqlite/app.py
@@ -458,7 +458,7 @@ async def by_order_id_products(order_id: int, ctx: EnrichContext) -> list[Produc
 
 
 # Define root resources
-@app.resource
+@app.retrieve
 async def list_users(ctx: EnrichContext) -> list[User]:
     """List all users in the system."""
     db: Database = ctx.request_context.lifespan_context["db"]
@@ -482,7 +482,7 @@ async def list_users(ctx: EnrichContext) -> list[User]:
     return users
 
 
-@app.resource
+@app.retrieve
 async def get_user(user_id: int, ctx: EnrichContext) -> User:
     """Get a specific user by ID."""
     db: Database = ctx.request_context.lifespan_context["db"]
@@ -510,7 +510,7 @@ async def get_user(user_id: int, ctx: EnrichContext) -> User:
     )
 
 
-@app.resource
+@app.retrieve
 async def list_products(ctx: EnrichContext) -> list[Product]:
     """List all products in the catalog."""
     db: Database = ctx.request_context.lifespan_context["db"]
@@ -534,7 +534,7 @@ async def list_products(ctx: EnrichContext) -> list[Product]:
     return products
 
 
-@app.resource
+@app.retrieve
 async def list_orders(
     ctx: EnrichContext, status: str | None = None, cursor: str | None = None, limit: int = 10
 ) -> CursorResult[Order]:

--- a/src/enrichmcp/context.py
+++ b/src/enrichmcp/context.py
@@ -20,7 +20,7 @@ class EnrichContext(Context):  # pyright: ignore[reportMissingTypeArgument]
     - Lifespan context (e.g., database connections)
 
     Example:
-        @app.resource
+        @app.retrieve
         async def get_user(user_id: int, ctx: EnrichContext) -> User:
             ctx.info(f"Fetching user {user_id}")
             db = ctx.request_context.lifespan_context["db"]

--- a/src/enrichmcp/relationship.py
+++ b/src/enrichmcp/relationship.py
@@ -83,7 +83,7 @@ class Relationship:
             self.resolvers.append((resolver_name, func))
 
             # If app is available, register as a resource
-            if self.app and hasattr(self.app, "resource"):
+            if self.app and hasattr(self.app, "retrieve"):
                 entity_name = self.owner_cls.__name__ if self.owner_cls else "Entity"
                 field_name = self.field_name or "field"
 
@@ -99,7 +99,7 @@ class Relationship:
                 ).strip()
 
                 # Register with app's resource system
-                resource_method = self.app.resource
+                resource_method = self.app.retrieve
                 return resource_method(name=resource_name, description=resource_description)(func)
 
             return func

--- a/src/enrichmcp/sqlalchemy/auto.py
+++ b/src/enrichmcp/sqlalchemy/auto.py
@@ -62,7 +62,7 @@ def _register_default_resources(
     # Ensure ctx annotation is an actual class for FastMCP before decorating
     list_resource.__annotations__["ctx"] = EnrichContext
 
-    list_resource = app.resource(name=list_name, description=list_description)(list_resource)
+    list_resource = app.retrieve(name=list_name, description=list_description)(list_resource)
 
     async def get_resource(ctx: EnrichContext, **kwargs: Any) -> enrich_model | None:  # type: ignore[name-defined]
         entity_id = kwargs.get(param_name)
@@ -77,7 +77,7 @@ def _register_default_resources(
     # Ensure ctx annotation is an actual class for FastMCP before decorating
     get_resource.__annotations__["ctx"] = EnrichContext
 
-    get_resource = app.resource(name=get_name, description=get_description)(get_resource)
+    get_resource = app.retrieve(name=get_name, description=get_description)(get_resource)
 
 
 def _register_relationship_resolvers(

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -66,7 +66,7 @@ async def test_resource_decorator():
     """Test resource decorator."""
     app = EnrichMCP("Test API", description="Test API description")
 
-    @app.resource(description="Get user resource")
+    @app.retrieve(description="Get user resource")
     async def get_user(*, id: int) -> dict:
         return {"id": id, "name": "Test User"}
 
@@ -82,7 +82,7 @@ async def test_resource_decorator_without_parens():
     """Test resource decorator without parentheses."""
     app = EnrichMCP("Test API", description="Test API description")
 
-    @app.resource
+    @app.retrieve
     async def get_user_no_parens(*, id: int) -> dict:
         """Get user by ID without parentheses in decorator."""
         return {"id": id, "name": "Test User"}
@@ -99,7 +99,7 @@ async def test_resource_decorator_empty_parens():
     """Test resource decorator with empty parentheses."""
     app = EnrichMCP("Test API", description="Test API description")
 
-    @app.resource()
+    @app.retrieve()
     async def get_user_empty_parens(*, id: int) -> dict:
         """Get user by ID with empty parentheses."""
         return {"id": id, "name": "Test User"}
@@ -116,7 +116,7 @@ async def test_resource_with_description():
     """Test resource decorator with description override."""
     app = EnrichMCP("Test API", description="Test API description")
 
-    @app.resource(name="custom_name", description="Custom resource description")
+    @app.retrieve(name="custom_name", description="Custom resource description")
     async def get_data() -> dict:
         """Original docstring that should be replaced."""
         return {"status": "ok"}
@@ -136,7 +136,7 @@ async def test_resource_without_description_fails():
 
     with pytest.raises(ValueError, match="must have a description"):
 
-        @app.resource
+        @app.retrieve
         async def bad_resource():
             # No docstring, should fail
             return {"status": "ok"}

--- a/tests/test_descriptions.py
+++ b/tests/test_descriptions.py
@@ -58,7 +58,7 @@ def test_resource_requires_description_via_parameter():
     app = EnrichMCP("Test API", description="Test API description")
 
     # Should work with a description
-    @app.resource(description="Test resource description")
+    @app.retrieve(description="Test resource description")
     async def test_resource():
         return {"status": "ok"}
 
@@ -70,7 +70,7 @@ def test_resource_accepts_function_docstring():
     app = EnrichMCP("Test API", description="Test API description")
 
     # Should work with a function docstring
-    @app.resource()
+    @app.retrieve()
     async def test_resource():
         """Test resource docstring."""
         return {"status": "ok"}
@@ -85,7 +85,7 @@ def test_resource_raises_error_without_description():
     # Should fail without a description
     with pytest.raises(ValueError) as exc_info:
 
-        @app.resource()
+        @app.retrieve()
         async def test_resource():
             return {"status": "ok"}
 
@@ -98,7 +98,7 @@ def test_resource_with_custom_name_and_description():
     app = EnrichMCP("Test API", description="Test API description")
 
     # Should work with custom name and description
-    @app.resource(name="custom_name", description="Custom resource description")
+    @app.retrieve(name="custom_name", description="Custom resource description")
     async def test_resource():
         return {"status": "ok"}
 

--- a/tests/test_pagination_integration.py
+++ b/tests/test_pagination_integration.py
@@ -104,7 +104,7 @@ class TestPaginatedResources:
         """Test page-based pagination in resource."""
         user_cls = app._test_user
 
-        @app.resource
+        @app.retrieve
         async def list_users(
             ctx: EnrichContext, page: int = 1, page_size: int = 10
         ) -> PageResult[user_cls]:
@@ -163,7 +163,7 @@ class TestPaginatedResources:
         """Test cursor-based pagination in resource."""
         user_cls = app._test_user
 
-        @app.resource
+        @app.retrieve
         async def list_users_cursor(
             ctx: EnrichContext, cursor: str | None = None, page_size: int = 10
         ) -> CursorResult[user_cls]:
@@ -215,7 +215,7 @@ class TestPaginatedResources:
         """Test pagination combined with filtering."""
         user_cls = app._test_user
 
-        @app.resource
+        @app.retrieve
         async def search_users(
             ctx: EnrichContext, name_contains: str, page: int = 1, page_size: int = 5
         ) -> PageResult[user_cls]:
@@ -257,7 +257,7 @@ class TestPaginatedResources:
         """Test pagination with no results."""
         user_cls = app._test_user
 
-        @app.resource
+        @app.retrieve
         async def list_empty_users(
             ctx: EnrichContext, page: int = 1, page_size: int = 10
         ) -> PageResult[user_cls]:
@@ -386,7 +386,7 @@ class TestPaginationParams:
         """Test using PaginationParams helper class."""
         user_cls = app._test_user
 
-        @app.resource
+        @app.retrieve
         async def list_users_with_params(
             ctx: EnrichContext, pagination: PaginationParams | None = None
         ) -> PageResult[user_cls]:
@@ -430,7 +430,7 @@ class TestPaginationParams:
         """Test using CursorParams helper class."""
         user_cls = app._test_user
 
-        @app.resource
+        @app.retrieve
         async def list_users_with_cursor_params(
             ctx: EnrichContext, cursor_params: CursorParams | None = None
         ) -> CursorResult[user_cls]:
@@ -478,7 +478,7 @@ class TestRealWorldScenarios:
             for i in range(1, 10001)  # 10,000 users
         ]
 
-        @app.resource
+        @app.retrieve
         async def list_large_dataset(
             ctx: EnrichContext, page: int = 1, page_size: int = 100
         ) -> PageResult[user_cls]:
@@ -522,7 +522,7 @@ class TestRealWorldScenarios:
             for i in range(1, 6)  # 5 users
         ]
 
-        @app.resource
+        @app.retrieve
         async def list_single_page(
             ctx: EnrichContext, page: int = 1, page_size: int = 10
         ) -> PageResult[user_cls]:


### PR DESCRIPTION
## Summary
- rename `app.resource` decorator to `app.retrieve`
- keep `app.resource` as deprecated alias
- update all code, docs, examples and tests for `@app.retrieve`
- document deprecation and add v0.4.2 changelog entry

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6854386e8874832a92aa6bb8f4acee3c