### PR TITLE
Run examples in CI with uv

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,10 +31,11 @@ jobs:
             requirements.txt
             requirements-dev.txt
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+        run: uv pip install -r requirements-dev.txt
 
       - name: Build documentation
         run: mkdocs build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,11 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+        run: uv pip install -r requirements-dev.txt
 
       - name: Build package
         run: python -m build

--- a/.github/workflows/test-publish.yml
+++ b/.github/workflows/test-publish.yml
@@ -31,11 +31,13 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements-dev.txt
-          python -m pip install -e .
+          uv pip install -r requirements-dev.txt
+          uv pip install -e .
 
       - name: Run tests
         run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ addopts = --cov=src/enrichmcp --cov-report=term --cov-report=html
 minversion = 6.0
 asyncio_mode = strict
 asyncio_default_fixture_loop_scope = function
+markers =
+    examples: run example scripts as tests


### PR DESCRIPTION
## Summary
- enable installing dependencies with uv in all workflows
- register `examples` marker for pytest

## Testing
- `pytest -q`
- `make examples-test`


------
https://chatgpt.com/codex/tasks/task_e_6855d32d4e50832a9e8d029567f194ca