### PR TITLE
Add mcp_use client example

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ Check out the [examples directory](examples/README.md):
 - [shop_api_sqlite](examples/shop_api_sqlite) - SQLite-backed version
 - [shop_api_gateway](examples/shop_api_gateway) - EnrichMCP as a gateway in front of FastAPI
 - [sqlalchemy_shop](examples/sqlalchemy_shop) - Auto-generated API from SQLAlchemy models
+- [mutable_crud](examples/mutable_crud) - Demonstrates mutable fields and CRUD decorators
+- [openai_chat_agent](examples/openai_chat_agent) - Interactive chat client for MCP examples
 
 ## Documentation
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,6 +2,16 @@
 
 This directory contains examples demonstrating how to use EnrichMCP.
 
+Available examples:
+
+- [hello_world](hello_world) - minimal "Hello, World" API
+- [shop_api](shop_api) - in-memory shop with relationships
+- [shop_api_sqlite](shop_api_sqlite) - SQLite-backed shop
+- [sqlalchemy_shop](sqlalchemy_shop) - SQLAlchemy ORM version
+- [shop_api_gateway](shop_api_gateway) - gateway in front of FastAPI
+- [mutable_crud](mutable_crud) - mutable fields and CRUD decorators
+- [openai_chat_agent](openai_chat_agent) - interactive chat client
+
 ## Hello World
 
 The simplest EnrichMCP application with a single resource that returns "Hello, World!".
@@ -108,7 +118,7 @@ uv run app.py
 ```
 
 Run the above commands from the `openai_chat_agent` directory so that
-`config.json` resolves the relative path to the `hello_world` example.
+`config.json` resolves the relative path to the `shop_api` example.
 
 If `OPENAI_API_KEY` is not set the agent defaults to a local Ollama model defined
 by `OLLAMA_MODEL` (defaults to `llama3`).
@@ -132,7 +142,7 @@ agent will fail to connect.
    ```
 
 The chat agent will fail to start if the server is not running.
-The included configuration starts the `hello_world` example using the MCP
+The included configuration starts the `shop_api` example using the MCP
 stdio connector so everything runs locally.
 This example demonstrates how to use `MCPAgent` with built-in conversation
 memory for chatting with your MCP data.

--- a/examples/hello_world/README.md
+++ b/examples/hello_world/README.md
@@ -1,0 +1,20 @@
+# Hello World Example
+
+A minimal EnrichMCP application exposing a single `hello_world` resource that returns a friendly greeting.
+
+```bash
+cd hello_world
+python app.py
+```
+
+The server listens on `http://localhost:8000`.
+
+## Calling the API with `mcp_use`
+
+Use the provided `client.py` script to start the server and invoke the `hello_world` tool programmatically:
+
+```bash
+python client.py
+```
+
+This creates an `MCPClient` using a small in-memory configuration, calls the `hello_world` tool, prints the response, and then shuts down the session.

--- a/examples/hello_world/client.py
+++ b/examples/hello_world/client.py
@@ -1,0 +1,33 @@
+"""Example mcp-use client for the Hello World API."""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+from mcp_use import MCPClient
+
+
+async def main() -> None:
+    example_path = Path(__file__).parent / "app.py"
+
+    config = {
+        "mcpServers": {
+            "hello": {
+                "command": sys.executable,
+                "args": [str(example_path)],
+            }
+        }
+    }
+
+    client = MCPClient(config=config)
+    session = await client.create_session("hello")
+    result = await session.connector.call_tool("hello_world", {})
+    print(result.content[0].text)
+
+    await client.close_all_sessions()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/openai_chat_agent/README.md
+++ b/examples/openai_chat_agent/README.md
@@ -1,0 +1,14 @@
+# OpenAI MCP Chat Agent
+
+An interactive command-line agent that connects to an MCP server and converses using either OpenAI or a local Ollama model.
+
+## Setup
+
+```bash
+cd openai_chat_agent
+uv pip install -r requirements.txt
+cp .env.example .env  # set OPENAI_API_KEY or adjust OLLAMA_MODEL
+uv run app.py
+```
+
+`config.json` points to the `shop_api` example so everything runs locally by default. If `OPENAI_API_KEY` is not provided the agent uses the model specified by `OLLAMA_MODEL` (default `llama3`). An Ollama server must be running when using this mode.


### PR DESCRIPTION
## Summary
- add `client.py` demonstrating mcp_use with the hello world example
- document the new helper script in the hello world README

## Testing
- `make lint-check`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6855db6c0c3c832abafac10cd07409c2