### PR TITLE
Add streamable HTTP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ The result: AI agents can work with your data as naturally as a developer using 
 Check out the [examples directory](examples/README.md):
 
 - [hello_world](examples/hello_world) - The smallest possible EnrichMCP app
+- [hello_world_http](examples/hello_world_http) - HTTP example using streamable HTTP
 - [shop_api](examples/shop_api) - In-memory shop API with pagination and filters
 - [shop_api_sqlite](examples/shop_api_sqlite) - SQLite-backed version
 - [shop_api_gateway](examples/shop_api_gateway) - EnrichMCP as a gateway in front of FastAPI

--- a/examples/README.md
+++ b/examples/README.md
@@ -2,9 +2,10 @@
 
 This directory contains examples demonstrating how to use EnrichMCP.
 
-Available examples:
+-Available examples:
 
 - [hello_world](hello_world) - minimal "Hello, World" API
+- [hello_world_http](hello_world_http) - HTTP version using streamable HTTP
 - [shop_api](shop_api) - in-memory shop with relationships
 - [shop_api_sqlite](shop_api_sqlite) - SQLite-backed shop
 - [sqlalchemy_shop](sqlalchemy_shop) - SQLAlchemy ORM version
@@ -19,6 +20,22 @@ The simplest EnrichMCP application with a single resource that returns "Hello, W
 ```bash
 cd hello_world
 python app.py
+```
+
+## Hello World HTTP
+
+A variant of the Hello World example that serves the API over HTTP using the
+streamable HTTP transport.
+
+```bash
+cd hello_world_http
+python app.py
+```
+
+Invoke the example using `mcp_use`:
+
+```bash
+python client.py
 ```
 
 ## Shop API

--- a/examples/hello_world_http/README.md
+++ b/examples/hello_world_http/README.md
@@ -1,0 +1,18 @@
+# Hello World HTTP Example
+
+A minimal EnrichMCP application served over **streamable HTTP** rather than the default stdio transport.
+
+```bash
+cd hello_world_http
+python app.py
+```
+
+The server listens on `http://localhost:8000/mcp`.
+
+## Calling the API with `mcp_use`
+
+Run the companion `client.py` script to call the `hello_http` tool using the official Python SDK:
+
+```bash
+python client.py
+```

--- a/examples/hello_world_http/app.py
+++ b/examples/hello_world_http/app.py
@@ -1,0 +1,18 @@
+"""Hello World HTTP example using EnrichMCP."""
+
+from enrichmcp import EnrichMCP
+
+
+def main() -> None:
+    app = EnrichMCP(title="Hello HTTP API", description="A simple HTTP example")
+
+    @app.retrieve(description="Say hello over HTTP")
+    async def hello_http() -> dict[str, str]:
+        return {"message": "Hello over HTTP!"}
+
+    print("Starting HTTP server on http://localhost:8000 ...")
+    app.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/hello_world_http/client.py
+++ b/examples/hello_world_http/client.py
@@ -1,0 +1,19 @@
+"""Simple mcp-use client for the HTTP example."""
+
+from __future__ import annotations
+
+import asyncio
+
+from mcp_use import MCPClient
+
+
+async def main() -> None:
+    client = MCPClient(config={"mcpServers": {"hello": {"url": "http://localhost:8000"}}})
+    session = await client.create_session("hello")
+    result = await session.connector.call_tool("hello_http", {})
+    print(result.content[0].text)
+    await client.close_all_sessions()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -427,7 +427,11 @@ class EnrichMCP:
         Start the MCP server.
 
         Args:
-            **options: Options to pass to the FastMCP run method
+            transport: Transport protocol to use when starting the server.
+                Supported values are "stdio", "sse", and "streamable-http".
+                If not provided, the default from ``FastMCP`` is used.
+            mount_path: Optional mount path for SSE transport.
+            **options: Additional options forwarded to ``FastMCP.run``.
 
         Returns:
             Result from FastMCP.run()
@@ -449,6 +453,12 @@ class EnrichMCP:
                 f"The following relationships are missing resolvers: {', '.join(unresolved)}. "
                 f"Define resolvers with @Entity.relationship.resolver"
             )
+
+        # Forward transport options to FastMCP
+        if transport is not None:
+            options.setdefault("transport", transport)
+        if mount_path is not None:
+            options.setdefault("mount_path", mount_path)
 
         # Run the MCP server
         return self.mcp.run(**options)


### PR DESCRIPTION
## Summary
- expose FastMCP `transport` and `mount_path` options in `EnrichMCP.run`
- document new example in README files
- add `hello_world_http` showing how to use streamable HTTP with `mcp_use`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685adc926b00832ab622988afc678eb4