### PR TITLE
Prepare 0.4.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3] - 2025-06-24
+
+### Added
+- HTTP transport via `app.run(transport="streamable-http")`
+- Basic memory example demonstrating `FileMemoryStore`
+- `mcp_use` client for the hello_world example
+
 ### Changed
-- List relationship resolvers generated from SQLAlchemy models now return
-  `PageResult` using `page` and `page_size` parameters without performing
-  count queries. `total_items` is omitted and `has_next` is inferred from
-  the query results.
+- SQLAlchemy relationship resolvers now return `PageResult` using
+  `page` and `page_size` parameters without count queries.
+
+### Fixed
+- Correct path handling in the HTTP example
 
 ## [0.4.2] - 2025-06-19
 

--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ async def get_user_profile(user_id: int, context: EnrichContext) -> UserProfile:
     return await db.get_profile(user_id)
 ```
 
+### 🌐 HTTP & SSE Support
+
+Serve your API over standard output (default), SSE, or HTTP:
+
+```python
+app.run()  # stdio default
+app.run(transport="streamable-http")
+```
+
 ## Why EnrichMCP?
 
 EnrichMCP adds three critical layers on top of MCP:
@@ -320,6 +329,7 @@ Check out the [examples directory](examples/README.md):
 - [shop_api_gateway](examples/shop_api_gateway) - EnrichMCP as a gateway in front of FastAPI
 - [sqlalchemy_shop](examples/sqlalchemy_shop) - Auto-generated API from SQLAlchemy models
 - [mutable_crud](examples/mutable_crud) - Demonstrates mutable fields and CRUD decorators
+- [basic_memory](examples/basic_memory) - Simple note-taking API using FileMemoryStore
 - [openai_chat_agent](examples/openai_chat_agent) - Interactive chat client for MCP examples
 
 ## Documentation

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -100,12 +100,15 @@ async def delete_user(uid: int) -> bool:
 Start the MCP server.
 
 **Parameters:**
-- `**options`: Options passed to FastMCP (transport, host, port, etc.)
+- `transport`: Transport protocol - `"stdio"`, `"sse"`, or `"streamable-http"`.
+- `mount_path`: Optional mount path for SSE transport.
+- `**options`: Additional options forwarded to FastMCP.
 
 **Example:**
 ```python
 if __name__ == "__main__":
-    app.run()
+    app.run()  # stdio default
+    app.run(transport="streamable-http")
 ```
 
 ### `describe_model() -> str`

--- a/docs/index.md
+++ b/docs/index.md
@@ -53,6 +53,9 @@ async def get_customer(customer_id: int) -> Customer:
 
 # Run it!
 app.run()
+
+# Serve over HTTP instead of stdio
+app.run(transport="streamable-http")
 ```
 
 Already using SQLAlchemy? See how to


### PR DESCRIPTION
## Summary
- document new HTTP transport in README and docs
- add `basic_memory` to example list
- record changes for v0.4.3
- correct docs to note `stdio` is the default transport

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_685ae577cfc8832a8010d54b5686aa11