### PR TITLE
Fix pip cache warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: ${{ matrix.python-version != '3.13' && 'pip' || '' }}
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,10 +26,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6


### PR DESCRIPTION
## Summary
- remove `cache: 'pip'` from GH workflows

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_685d928724e0832a94f67d4ab79c876c