### PR TITLE
Fix create_note and update mcp_use test

### DIFF
--- a/examples/basic_memory/app.py
+++ b/examples/basic_memory/app.py
@@ -37,9 +37,15 @@ class NoteSummary(MemoryNoteSummary):
 
 
 @app.create
-async def create_note(title: str, content: str, tags: list[str] | None = None) -> Note:
-    """Create and persist a new note."""
-    return project.create_note(title, content, tags)
+async def create_note(
+    title: str,
+    content: str,
+    tags: list[str] | None = None,
+    note_id: str | None = None,
+) -> Note:
+    """Create or replace a note."""
+    note = project.create_note(title, content, tags, note_id=note_id)
+    return Note.model_validate(note.model_dump())
 
 
 @app.retrieve

--- a/examples/basic_memory/memory.py
+++ b/examples/basic_memory/memory.py
@@ -148,8 +148,20 @@ class MemoryProject:
         self.name = name
         self.store = store
 
-    def create_note(self, title: str, content: str, tags: list[str] | None = None) -> MemoryNote:
-        note = MemoryNote(id=self.store.new_id(), title=title, content=content, tags=tags or [])
+    def create_note(
+        self,
+        title: str,
+        content: str,
+        tags: list[str] | None = None,
+        note_id: str | None = None,
+    ) -> MemoryNote:
+        """Create a new note or overwrite an existing one."""
+        note = MemoryNote(
+            id=note_id or self.store.new_id(),
+            title=title,
+            content=content,
+            tags=tags or [],
+        )
         self.store.save(self.name, note)
         return note
 

--- a/tests/test_basic_memory_mcp_use.py
+++ b/tests/test_basic_memory_mcp_use.py
@@ -1,0 +1,100 @@
+import json
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+from mcp_use import MCPClient
+
+
+@pytest.mark.asyncio
+async def test_basic_memory_mcp_use(tmp_path: Path) -> None:
+    script = tmp_path / "app.py"
+    # Paths to the repository root and example memory module
+    repo_root = Path(__file__).resolve().parents[1]
+    examples_dir = repo_root / "examples" / "basic_memory"
+    script.write_text(
+        textwrap.dedent(
+            f'''
+            import sys
+            from pathlib import Path
+
+            sys.path.insert(0, {str(repo_root / "src")!r})
+            sys.path.insert(0, {str(examples_dir)!r})
+            from memory import FileMemoryStore, MemoryNote, MemoryNoteSummary, MemoryProject
+            from enrichmcp import EnrichMCP
+
+            store = FileMemoryStore(Path(__file__).parent / "data")
+            project = MemoryProject("demo", store)
+
+            app = EnrichMCP(title="Test", description="Desc")
+
+            @app.entity
+            class Note(MemoryNote):
+                """A note stored in the demo project."""
+
+                pass
+
+            @app.entity
+            class NoteSummary(MemoryNoteSummary):
+                """Minimal note representation."""
+
+                pass
+
+            @app.create
+            async def create_note(
+                title: str,
+                content: str,
+                tags: list[str] | None = None,
+                note_id: str | None = None,
+            ) -> Note:
+                """Create or replace a note."""
+                note = project.create_note(title, content, tags, note_id=note_id)
+                return Note.model_validate(note.model_dump())
+
+            @app.retrieve
+            async def get_note(note_id: str) -> Note:
+                """Get a note by ID."""
+                note = project.get_note(note_id)
+                if note is None:
+                    raise ValueError("note not found")
+                return Note.model_validate(note.model_dump())
+
+            @app.retrieve
+            async def list_notes(page: int = 1, page_size: int = 10) -> list[NoteSummary]:
+                """List notes with pagination."""
+                notes = project.list_notes(page, page_size)
+                return [NoteSummary.model_validate(n.model_dump()) for n in notes]
+
+            if __name__ == "__main__":
+                app.run()
+            '''
+        )
+    )
+
+    config = {"mcpServers": {"app": {"command": sys.executable, "args": [str(script)]}}}
+    client = MCPClient(config=config)
+    session = await client.create_session("app")
+
+    create_result = await session.connector.call_tool(
+        "create_note", {"title": "First", "content": "Hello", "tags": []}
+    )
+    note = json.loads(create_result.content[0].text)
+
+    update_result = await session.connector.call_tool(
+        "create_note",
+        {
+            "note_id": note["id"],
+            "title": "Updated",
+            "content": "New text",
+            "tags": ["x"],
+        },
+    )
+    updated = json.loads(update_result.content[0].text)
+    assert updated["title"] == "Updated"
+
+    get_result = await session.connector.call_tool("get_note", {"note_id": note["id"]})
+    fetched = json.loads(get_result.content[0].text)
+    assert fetched["content"] == "New text"
+
+    await client.close_all_sessions()


### PR DESCRIPTION
## Summary
- allow passing a note_id when creating notes in the basic memory example
- remove the unused set_note helper and endpoint
- adjust the mcp_use test to call create_note for both creation and replacement

## Testing
- `pytest -q tests/test_basic_memory_mcp_use.py::test_basic_memory_mcp_use -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_685db791224c832abe345df3510835d6