### PR TITLE
Improve cache namespace isolation

### DIFF
--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -445,9 +445,8 @@ class EnrichMCP:
 
         base_ctx = self.mcp.get_context()
         request_ctx = getattr(base_ctx, "_request_context", None)
-        request_id = (
-            str(getattr(request_ctx, "request_id", "no-request")) if request_ctx else "no-request"
-        )
+        rid = str(getattr(request_ctx, "request_id", "")) if request_ctx else ""
+        request_id = rid if rid else uuid4().hex
         ctx = EnrichContext.model_construct(
             _request_context=request_ctx,
             _fastmcp=getattr(base_ctx, "_fastmcp", None),

--- a/src/enrichmcp/cache/__init__.py
+++ b/src/enrichmcp/cache/__init__.py
@@ -5,10 +5,12 @@ from __future__ import annotations
 import asyncio
 import hashlib
 import pickle
+import re
 import time
 import warnings
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
+from uuid import uuid4
 
 if TYPE_CHECKING:  # pragma: no cover - used for type hints
     from collections.abc import Callable
@@ -99,7 +101,8 @@ class ContextCache:
     def __init__(self, backend: CacheBackend, cache_id: str, request_id: str) -> None:
         self._backend = backend
         self._cache_id = cache_id
-        self._request_id = request_id
+        cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", str(request_id))
+        self._request_id = cleaned if cleaned else uuid4().hex
 
     def _user_hash(self) -> str | None:
         try:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -45,3 +45,14 @@ async def test_user_scope_warns_and_falls_back(monkeypatch):
         ns = cache._build_namespace("user")
 
     assert ns == cache._build_namespace("request")
+
+
+@pytest.mark.asyncio
+async def test_request_id_sanitization_and_unique_fallback():
+    backend = MemoryCache()
+    cache = ContextCache(backend, "app", "bad:id")
+    assert cache._build_namespace("request") == "enrichmcp:request:app:bad_id"
+
+    c1 = ContextCache(backend, "app", "")
+    c2 = ContextCache(backend, "app", "")
+    assert c1._request_id != c2._request_id


### PR DESCRIPTION
## Summary
- sanitize request_id on context cache
- generate unique request IDs when missing
- test request ID sanitation and fallback

## Testing
- `pytest tests/test_cache.py::test_request_id_sanitization_and_unique_fallback -q`
- `pytest tests/test_cache.py::test_memory_cache_ttl_and_delete tests/test_cache.py::test_context_cache_get_or_set tests/test_cache.py::test_user_scope_warns_and_falls_back -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bcf2fdd0832aa9c1303b009bde5e