### PR TITLE
Fix tests warnings and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ auto-generated patch models for updates:
 @app.entity
 class Customer(EnrichModel):
     id: int = Field(description="ID")
-    email: str = Field(mutable=True, description="Email")
+    email: str = Field(json_schema_extra={"mutable": True}, description="Email")
 
 @app.create
 async def create_customer(email: str) -> Customer:

--- a/docs/api/entity.md
+++ b/docs/api/entity.md
@@ -157,13 +157,13 @@ metadata: dict[str, Any] = Field(description="Arbitrary metadata", default_facto
 
 ### Mutable Fields
 
-Fields are immutable unless `mutable=True`:
+Fields are immutable unless `json_schema_extra={"mutable": True}`:
 
 ```python
 @app.entity
 class Customer(EnrichModel):
     id: int = Field(description="ID")
-    email: str = Field(mutable=True, description="Email")
+    email: str = Field(json_schema_extra={"mutable": True}, description="Email")
 
     # Customer.PatchModel is generated automatically
 ```

--- a/examples/mutable_crud/app.py
+++ b/examples/mutable_crud/app.py
@@ -16,8 +16,10 @@ class Customer(EnrichModel):
 
     id: int = Field(description="Customer ID")
     created_at: datetime = Field(default_factory=datetime.utcnow, description="Creation timestamp")
-    email: str = Field(mutable=True, description="Email address")
-    tier: str = Field(mutable=True, description="Subscription tier", default="free")
+    email: str = Field(json_schema_extra={"mutable": True}, description="Email address")
+    tier: str = Field(
+        json_schema_extra={"mutable": True}, description="Subscription tier", default="free"
+    )
 
 
 CUSTOMERS: dict[int, Customer] = {}

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,3 +8,5 @@ addopts = --cov=src/enrichmcp --cov-report=term --cov-report=html
 minversion = 6.0
 asyncio_mode = strict
 asyncio_default_fixture_loop_scope = function
+markers =
+    examples: marks tests that run example applications

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -13,8 +13,8 @@ async def test_patch_model_generation_and_mutable_fields():
         """Customer entity."""
 
         id: int = Field(description="id")
-        email: str = Field(description="email", mutable=True)
-        status: str = Field(description="status", mutable=True)
+        email: str = Field(description="email", json_schema_extra={"mutable": True})
+        status: str = Field(description="status", json_schema_extra={"mutable": True})
 
     # mutable fields detected
     assert Customer.mutable_fields() == {"email", "status"}
@@ -32,7 +32,7 @@ async def test_crud_decorators_register_resources():
         """Item entity."""
 
         id: int = Field(description="id")
-        name: str = Field(description="name", mutable=True)
+        name: str = Field(description="name", json_schema_extra={"mutable": True})
 
     @app.create
     async def create_item(name: str) -> Item:

--- a/uv.lock
+++ b/uv.lock
@@ -200,7 +200,7 @@ more-itertools==10.7.0
     # via
     #   jaraco-classes
     #   jaraco-functools
-multidict==6.5.0
+multidict==6.6.3
     # via
     #   aiohttp
     #   yarl


### PR DESCRIPTION
## Summary
- remove pytest warnings by registering the `examples` mark
- avoid deprecated `Field(mutable=True)` usage
- update docs and example to show new `json_schema_extra` syntax
- bump `multidict` to avoid yanked version

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6865bd65c388832ab2a602b8898ad8b6