### PR TITLE
Prepare 0.4.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.4.5] - 2025-07-02
 ### Added
 - Context caching with `MemoryCache` and optional `RedisCache` backends.
 - `EnrichMCP.get_context()` returns an `EnrichContext` instance mirroring the underlying FastMCP context.


### PR DESCRIPTION
## Summary
- note context cache changes for 0.4.5

## Testing
- `make setup`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6865bd429620832ab7657971c10624c5