### PR TITLE
Support EnrichParameter metadata hints

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,20 @@ async def get_customer(cid: int, ctx: EnrichContext) -> Customer:
     return await ctx.cache.get_or_set(f"customer:{cid}", fetch)
 ```
 
+### 🧭 Parameter Hints
+
+Provide examples and metadata for tool parameters using `EnrichParameter`:
+
+```python
+from enrichmcp import EnrichParameter
+
+@app.retrieve
+async def greet_user(name: str = EnrichParameter(description="user name", examples=["bob"])) -> str:
+    return f"Hello {name}"
+```
+
+Tool descriptions will include the parameter type, description, and examples.
+
 ### 🌐 HTTP & SSE Support
 
 Serve your API over standard output (default), SSE, or HTTP:

--- a/docs/api.md
+++ b/docs/api.md
@@ -41,6 +41,9 @@ class User(EnrichModel):
 ### [EnrichContext](api/context.md)
 Context object with request scoped utilities including caching.
 
+### [EnrichParameter](api/parameter.md)
+Attach metadata like descriptions and examples to function parameters.
+
 ### [Cache](api/cache.md)
 Request, user, and global scoped caching utilities.
 

--- a/docs/api/parameter.md
+++ b/docs/api/parameter.md
@@ -1,0 +1,14 @@
+# Parameter Metadata
+
+`EnrichParameter` attaches hints like descriptions and examples to function parameters.
+When a parameter's default value is an instance of `EnrichParameter`, those hints
+are appended to the generated tool description (except for parameters typed as
+`EnrichContext`).
+
+```python
+from enrichmcp import EnrichParameter
+
+@app.retrieve
+async def greet(name: str = EnrichParameter(description="user name", examples=["bob"])) -> str:
+    return f"Hello {name}"
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -191,6 +191,20 @@ async def get_user(user_id: int, ctx: EnrichContext) -> User:
 
 Context is automatically injected when you add a parameter typed as `EnrichContext`.
 
+## Parameter Hints
+
+You can attach descriptions and examples to resource parameters using `EnrichParameter`:
+
+```python
+from enrichmcp import EnrichParameter
+
+@app.retrieve
+async def greet(name: str = EnrichParameter(description="user name", examples=["bob"])) -> str:
+    return f"Hello {name}"
+```
+
+These hints are appended to the generated tool description so agents know how to call the resource.
+
 ## Using Existing SQLAlchemy Models
 
 Have a project full of SQLAlchemy models already? You can expose them as an MCP

--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -30,6 +30,7 @@ from .context import EnrichContext
 from .entity import EnrichModel
 from .lifespan import combine_lifespans
 from .pagination import CursorParams, CursorResult, PageResult, PaginatedResult, PaginationParams
+from .parameter import EnrichParameter
 from .relationship import (
     Relationship,
 )
@@ -52,6 +53,7 @@ __all__ = [
     "EnrichContext",
     "EnrichMCP",
     "EnrichModel",
+    "EnrichParameter",
     "MemoryCache",
     "PageResult",
     "PaginatedResult",

--- a/src/enrichmcp/parameter.py
+++ b/src/enrichmcp/parameter.py
@@ -1,0 +1,29 @@
+"""Utility for annotating function parameters with extra metadata."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from dataclasses import field as dataclass_field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - import for type hints
+    from collections.abc import Iterable
+
+
+@dataclass
+class EnrichParameter:
+    """Metadata container for function parameters.
+
+    When a parameter's default value is an instance of ``EnrichParameter`` the
+    metadata contained here is appended to the generated tool description. The
+    ``default`` attribute is **not** used as the runtime default value; it simply
+    provides a placeholder so function signatures remain valid.
+    """
+
+    default: Any | None = None
+    description: str | None = None
+    examples: Iterable[Any] | None = None
+    metadata: dict[str, Any] = dataclass_field(default_factory=dict)
+
+    def __iter__(self) -> Iterable[Any]:  # pragma: no cover - convenience
+        yield self.default

--- a/tests/test_enrichparameter.py
+++ b/tests/test_enrichparameter.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+import pytest
+
+from enrichmcp import EnrichContext, EnrichMCP, EnrichParameter
+
+
+@pytest.mark.asyncio
+async def test_enrichparameter_hints_appended():
+    app = EnrichMCP("Test", description="desc")
+    with patch.object(app.mcp, "tool", wraps=app.mcp.tool) as mock_tool:
+
+        @app.retrieve(description="Base desc")
+        async def my_resource(
+            ctx: EnrichContext,
+            name: str = EnrichParameter(description="user name", examples=["bob"]),
+        ) -> dict:
+            return {}
+
+    desc = mock_tool.call_args.kwargs["description"]
+    assert "Parameter hints:" in desc
+    assert "name - str" in desc
+    assert "user name" in desc
+    assert "examples: bob" in desc
+    assert "ctx" not in desc


### PR DESCRIPTION
## Summary
- add `EnrichParameter` helper for parameter metadata
- include `EnrichParameter` info in resource descriptions
- export `EnrichParameter` from package
- mention parameter metadata in README and docs
- test parameter hint behaviour

## Testing
- `ruff check src tests --fix --no-cache`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686d488f4448832a810cab52497ac8d5