### PR TITLE
Add DataModelSummary class and dynamic explore resource

### DIFF
--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 from .app import EnrichMCP
 from .cache import MemoryCache, RedisCache
 from .context import EnrichContext
+from .datamodel import DataModelSummary
 from .entity import EnrichModel
 from .lifespan import combine_lifespans
 from .pagination import CursorParams, CursorResult, PageResult, PaginatedResult, PaginationParams
@@ -49,6 +50,7 @@ else:
 __all__ = [
     "CursorParams",
     "CursorResult",
+    "DataModelSummary",
     "EnrichContext",
     "EnrichMCP",
     "EnrichModel",

--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field, create_model
 
 from .cache import CacheBackend, ContextCache, MemoryCache
 from .context import EnrichContext
+from .datamodel import DataModelSummary
 from .entity import EnrichModel
 from .relationship import Relationship
 
@@ -83,17 +84,18 @@ class EnrichMCP:
         Register built-in resources for the API.
         """
 
-        @self.retrieve(
-            name="explore_data_model",
-            description=(
-                "IMPORTANT: Call this tool FIRST to understand the complete data model, "
-                "entity relationships, and available operations. This provides a comprehensive "
-                "overview of the API structure, including all entities, their fields, "
-                "relationships, and semantic meanings. Understanding this model is essential "
-                "for effectively querying and navigating the data."
-            ),
+        tool_name = f"explore_{self.name.lower().replace(' ', '_')}_data_model"
+        tool_description = (
+            "IMPORTANT: Call this tool FIRST before using any other tools on the "
+            f"{self.title} server. {self.description} "
+            "This provides a comprehensive overview of the API structure, including "
+            "all entities, their fields, relationships, and semantic meanings. "
+            "Understanding this model is essential for effectively querying and "
+            "navigating the data."
         )
-        async def explore_data_model() -> dict[str, Any]:  # pyright: ignore[reportUnusedFunction]
+
+        @self.retrieve(name=tool_name, description=tool_description)
+        async def explore_data_model() -> "DataModelSummary":  # pyright: ignore[reportUnusedFunction]
             """Get a comprehensive overview of the API data model.
 
             Returns detailed information about all entities, their fields, relationships,
@@ -101,18 +103,18 @@ class EnrichMCP:
             the available data and operations.
             """
             model_description = self.describe_model()
-            return {
-                "title": self.title,
-                "description": self.description,
-                "entity_count": len(self.entities),
-                "entities": list(self.entities.keys()),
-                "model": model_description,
-                "usage_hint": (
+            return DataModelSummary(
+                title=self.title,
+                description=self.description,
+                entity_count=len(self.entities),
+                entities=list(self.entities.keys()),
+                model=model_description,
+                usage_hint=(
                     "Use the model information above to understand how to query the data. "
                     "Each entity has fields and relationships. Relationships must be resolved "
                     "separately using their specific resolver endpoints."
                 ),
-            }
+            )
 
     def entity(
         self, cls: type[EnrichModel] | None = None, *, description: str | None = None

--- a/src/enrichmcp/datamodel.py
+++ b/src/enrichmcp/datamodel.py
@@ -1,0 +1,32 @@
+"""Data model summary types."""
+
+from pydantic import BaseModel, Field
+
+
+class DataModelSummary(BaseModel):
+    """Summary of all entities registered with an :class:`~enrichmcp.EnrichMCP` app."""
+
+    title: str = Field(description="Application title")
+    description: str = Field(description="Application description")
+    entity_count: int = Field(description="Number of registered entities")
+    entities: list[str] = Field(description="Entity names")
+    model: str = Field(description="Full Markdown model description")
+    usage_hint: str = Field(description="Hint on how to use the model information")
+
+    def __str__(self) -> str:  # pragma: no cover - simple formatting
+        """Return a human-readable Markdown summary."""
+        lines = [f"# {self.title}"]
+        if self.description:
+            lines.append(self.description)
+        lines.append("")
+        lines.append(f"**Entity count:** {self.entity_count}")
+        if self.entities:
+            lines.append("")
+            lines.append("## Entities")
+            for name in sorted(self.entities):
+                lines.append(f"- {name}")
+        lines.append("")
+        lines.append(self.model)
+        lines.append("")
+        lines.append(self.usage_hint)
+        return "\n".join(lines)

--- a/tests/test_explore_data_model.py
+++ b/tests/test_explore_data_model.py
@@ -1,0 +1,31 @@
+import pytest
+from pydantic import Field
+
+from enrichmcp import DataModelSummary, EnrichMCP, EnrichModel
+
+
+@pytest.mark.asyncio
+async def test_explore_data_model_returns_summary() -> None:
+    app = EnrichMCP("My API", description="Demo server")
+
+    @app.entity(description="Test entity")
+    class Item(EnrichModel):
+        id: int = Field(description="Identifier")
+
+    tool_name = "explore_my_api_data_model"
+    assert tool_name in app.resources
+
+    summary = await app.resources[tool_name]()
+    assert isinstance(summary, DataModelSummary)
+    assert summary.title == "My API"
+    assert summary.entity_count == 1
+    assert summary.entities == ["Item"]
+    summary_text = str(summary)
+    assert "# My API" in summary_text
+    assert "**Entity count:** 1" in summary_text
+    assert "- Item" in summary_text
+
+    tools = await app.mcp.list_tools()
+    tool = next(t for t in tools if t.name == tool_name)
+    assert "Call this tool FIRST" in tool.description
+    assert "Demo server" in tool.description


### PR DESCRIPTION
## Summary
- introduce `DataModelSummary` to wrap explore data model output
- export new class from package
- return `DataModelSummary` in `explore_data_model` and compute its name/description from the app
- test the new behaviour
- improve `__str__` output of `DataModelSummary`

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686eab2bd8d4832abbc7af689d1a7296