### PR TITLE
Improve docs with development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,20 @@ Check out the [examples directory](examples/README.md):
 
 We welcome contributions! See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
+## Development Setup
+
+The repository requires **Python&nbsp;3.11** or newer. The Makefile includes
+commands to create a virtual environment and run the tests:
+
+```bash
+make setup            # create .venv and install dependencies
+source .venv/bin/activate
+make test             # run the test suite
+```
+
+This installs all development extras and pre-commit hooks so commands like
+`make lint` or `make docs` work right away.
+
 ## License
 
 Apache 2.0 - See [LICENSE](LICENSE)

--- a/docs/index.md
+++ b/docs/index.md
@@ -115,6 +115,7 @@ pip install enrichmcp
 - Explore the [API Reference](api.md)
 - Check out [Examples](https://github.com/featureform/enrichmcp/tree/main/examples)
 - Learn about [SQLAlchemy integration](sqlalchemy.md)
+- Read the [Development Setup](../README.md#development-setup) guide if you want to contribute
 
 ## Support
 


### PR DESCRIPTION
## Summary
- add instructions for running tests to `README`
- reference Development Setup from docs index

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_686f7b57e360832a9d24a127e023611d