### PR TITLE
Update explore_data_model tests for new summary class

### DIFF
--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -27,7 +27,13 @@ from typing import TYPE_CHECKING
 from .app import EnrichMCP
 from .cache import MemoryCache, RedisCache
 from .context import EnrichContext
-from .datamodel import DataModelSummary
+from .datamodel import (
+    DataModelSummary,
+    EntityDescription,
+    FieldDescription,
+    ModelDescription,
+    RelationshipDescription,
+)
 from .entity import EnrichModel
 from .lifespan import combine_lifespans
 from .pagination import CursorParams, CursorResult, PageResult, PaginatedResult, PaginationParams
@@ -56,12 +62,16 @@ __all__ = [
     "EnrichMCP",
     "EnrichModel",
     "EnrichParameter",
+    "EntityDescription",
+    "FieldDescription",
     "MemoryCache",
+    "ModelDescription",
     "PageResult",
     "PaginatedResult",
     "PaginationParams",
     "RedisCache",
     "Relationship",
+    "RelationshipDescription",
     "__version__",
     "combine_lifespans",
 ]

--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -24,7 +24,13 @@ from pydantic import BaseModel, Field, create_model
 
 from .cache import CacheBackend, ContextCache, MemoryCache
 from .context import EnrichContext
-from .datamodel import DataModelSummary
+from .datamodel import (
+    DataModelSummary,
+    EntityDescription,
+    FieldDescription,
+    ModelDescription,
+    RelationshipDescription,
+)
 from .entity import EnrichModel
 from .parameter import EnrichParameter
 from .relationship import Relationship
@@ -236,93 +242,69 @@ class EnrichMCP:
             patch_model_cls.__doc__ = f"Patch model for {cls.__name__}"
             cls.PatchModel = patch_model_cls
 
-    def describe_model(self) -> str:
-        """
-        Generate a comprehensive description of the entire data model.
+    def describe_model_struct(self) -> ModelDescription:
+        """Return a structured description of the entire data model."""
+        desc = ModelDescription(title=self.title, description=self.description)
 
-        Returns:
-            A formatted string containing all entities, their fields, and relationships.
-        """
-        lines: list[str] = []
-
-        # Add title
-        lines.append(f"# Data Model: {self.title}")
-        if self.description:
-            lines.append(self.description)
-        lines.append("")
-
-        # Add table of contents
-        if self.entities:
-            lines.append("## Entities")
-            for entity_name in sorted(self.entities.keys()):
-                lines.append(f"- [{entity_name}](#{entity_name.lower()})")
-            lines.append("")
-        else:
-            lines.append("*No entities registered*")
-            return "\n".join(lines)
-
-        # Add each entity
         for entity_name, entity_cls in sorted(self.entities.items()):
-            lines.append(f"## {entity_name}")
-            description = entity_cls.__doc__ or "No description available"
-            lines.append(description.strip())
-            lines.append("")
+            entity_desc = EntityDescription(
+                name=entity_name,
+                description=(entity_cls.__doc__ or "No description available").strip(),
+            )
 
-            # Fields section
-            field_lines: list[str] = []
             for field_name, field in entity_cls.model_fields.items():
-                # Skip relationship fields, we'll handle them separately
                 if field_name in entity_cls.relationship_fields():
                     continue
 
-                # Get field type and description
-                field_type = "Any"  # Default type if annotation is None
+                field_type = "Any"
                 if field.annotation is not None:
                     annotation = field.annotation
                     if get_origin(annotation) is Literal:
                         values = ", ".join(repr(v) for v in get_args(annotation))
                         field_type = f"Literal[{values}]"
                     else:
-                        field_type = str(annotation)  # Always safe fallback
+                        field_type = str(annotation)
                         if hasattr(annotation, "__name__"):
                             field_type = annotation.__name__
-                field_desc = field.description
+
                 extra = getattr(field, "json_schema_extra", None)
                 if extra is None:
                     info = getattr(field, "field_info", None)
                     extra = getattr(info, "extra", {}) if info is not None else {}
-                if extra.get("mutable"):
-                    field_type = f"{field_type}, mutable"
 
-                # Format field info
-                field_lines.append(f"- **{field_name}** ({field_type}): {field_desc}")
+                entity_desc.fields.append(
+                    FieldDescription(
+                        name=field_name,
+                        type=field_type,
+                        description=field.description,
+                        mutable=bool(extra.get("mutable")),
+                    )
+                )
 
-            if field_lines:
-                lines.append("### Fields")
-                lines.extend(field_lines)
-                lines.append("")
-
-            # Relationships section
-            rel_lines: list[str] = []
-            rel_fields = entity_cls.relationship_fields()
-            for field_name in rel_fields:
+            for field_name in entity_cls.relationship_fields():
                 field = entity_cls.model_fields[field_name]
                 rel = field.default
-                target_type = "Any"  # Default type if annotation is None
+                target_type = "Any"
                 if field.annotation is not None:
-                    target_type = str(field.annotation)  # Always safe fallback
+                    target_type = str(field.annotation)
                     if hasattr(field.annotation, "__name__"):
                         target_type = field.annotation.__name__
-                rel_desc = rel.description
 
-                rel_lines.append(f"- **{field_name}** → {target_type}: {rel_desc}")
+                entity_desc.relationships.append(
+                    RelationshipDescription(
+                        name=field_name,
+                        target=target_type,
+                        description=rel.description,
+                    )
+                )
 
-            if rel_lines:
-                lines.append("### Relationships")
-                lines.extend(rel_lines)
-                lines.append("")
+            desc.entities.append(entity_desc)
 
-        return "\n".join(lines)
+        return desc
+
+    def describe_model(self) -> str:
+        """Return a Markdown description of the entire data model."""
+        return str(self.describe_model_struct())
 
     def _append_enrichparameter_hints(self, description: str, fn: Callable[..., Any]) -> str:
         """Append ``EnrichParameter`` metadata to a description string."""

--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -276,7 +276,7 @@ class EnrichMCP:
                     FieldDescription(
                         name=field_name,
                         type=field_type,
-                        description=field.description,
+                        description=field.description or "",
                         mutable=bool(extra.get("mutable")),
                     )
                 )

--- a/src/enrichmcp/datamodel.py
+++ b/src/enrichmcp/datamodel.py
@@ -3,6 +3,77 @@
 from pydantic import BaseModel, Field
 
 
+class FieldDescription(BaseModel):
+    """Description of a model field."""
+
+    name: str
+    type: str
+    description: str
+    mutable: bool = False
+
+    def __str__(self) -> str:
+        type_repr = self.type
+        if self.mutable and "mutable" not in type_repr:
+            type_repr = f"{type_repr}, mutable"
+        return f"- **{self.name}** ({type_repr}): {self.description}"
+
+
+class RelationshipDescription(BaseModel):
+    """Description of a relationship field."""
+
+    name: str
+    target: str
+    description: str
+
+    def __str__(self) -> str:
+        return f"- **{self.name}** → {self.target}: {self.description}"
+
+
+class EntityDescription(BaseModel):
+    """Description of a single entity."""
+
+    name: str
+    description: str
+    fields: list[FieldDescription] = Field(default_factory=list)
+    relationships: list[RelationshipDescription] = Field(default_factory=list)
+
+    def __str__(self) -> str:
+        lines = [f"## {self.name}", self.description, ""]
+        if self.fields:
+            lines.append("### Fields")
+            lines.extend(str(f) for f in self.fields)
+            lines.append("")
+        if self.relationships:
+            lines.append("### Relationships")
+            lines.extend(str(r) for r in self.relationships)
+            lines.append("")
+        return "\n".join(lines)
+
+
+class ModelDescription(BaseModel):
+    """Structured representation of the entire data model."""
+
+    title: str
+    description: str
+    entities: list[EntityDescription] = Field(default_factory=list)
+
+    def __str__(self) -> str:
+        lines = [f"# Data Model: {self.title}"]
+        if self.description:
+            lines.append(self.description)
+        lines.append("")
+        if self.entities:
+            lines.append("## Entities")
+            for e in sorted(self.entities, key=lambda ent: ent.name):
+                lines.append(f"- [{e.name}](#{e.name.lower()})")
+            lines.append("")
+            for e in sorted(self.entities, key=lambda ent: ent.name):
+                lines.append(str(e))
+        else:
+            lines.append("*No entities registered*")
+        return "\n".join(lines)
+
+
 class DataModelSummary(BaseModel):
     """Summary of all entities registered with an :class:`~enrichmcp.EnrichMCP` app."""
 
@@ -13,7 +84,7 @@ class DataModelSummary(BaseModel):
     model: str = Field(description="Full Markdown model description")
     usage_hint: str = Field(description="Hint on how to use the model information")
 
-    def __str__(self) -> str:  # pragma: no cover - simple formatting
+    def __str__(self) -> str:
         """Return a human-readable Markdown summary."""
         lines = [f"# {self.title}"]
         if self.description:
@@ -26,7 +97,7 @@ class DataModelSummary(BaseModel):
             for name in sorted(self.entities):
                 lines.append(f"- {name}")
         lines.append("")
-        lines.append(self.model)
+        lines.append(str(self.model))
         lines.append("")
         lines.append(self.usage_hint)
         return "\n".join(lines)

--- a/tests/test_datamodel_summary.py
+++ b/tests/test_datamodel_summary.py
@@ -1,0 +1,43 @@
+from enrichmcp.datamodel import DataModelSummary, ModelDescription
+
+
+def test_datamodelsummary_str_no_entities() -> None:
+    model = ModelDescription(title="M", description="", entities=[])
+    summary = DataModelSummary(
+        title="Empty",
+        description="A test",
+        entity_count=0,
+        entities=[],
+        model=str(model),
+        usage_hint="HINT",
+    )
+    expected = "\n".join(
+        [
+            "# Empty",
+            "A test",
+            "",
+            "**Entity count:** 0",
+            "",
+            str(model),
+            "",
+            "HINT",
+        ]
+    )
+    assert str(summary) == expected
+
+
+def test_datamodelsummary_str_sorted_entities() -> None:
+    model = ModelDescription(title="M", description="", entities=[])
+    summary = DataModelSummary(
+        title="Test",
+        description="",
+        entity_count=3,
+        entities=["B", "A", "C"],
+        model=str(model),
+        usage_hint="HINT",
+    )
+    text = str(summary)
+    lines = text.splitlines()
+    idx = lines.index("## Entities")
+    assert lines[idx + 1 : idx + 4] == ["- A", "- B", "- C"]
+    assert lines[-1] == "HINT"

--- a/tests/test_description_str.py
+++ b/tests/test_description_str.py
@@ -1,0 +1,42 @@
+from enrichmcp.datamodel import (
+    EntityDescription,
+    FieldDescription,
+    ModelDescription,
+    RelationshipDescription,
+)
+
+
+def test_description_str_functions() -> None:
+    field = FieldDescription(
+        name="id",
+        type="int",
+        description="Identifier",
+        mutable=True,
+    )
+    rel = RelationshipDescription(
+        name="owner",
+        target="User",
+        description="Item owner",
+    )
+    entity = EntityDescription(
+        name="Item",
+        description="A simple item",
+        fields=[field],
+        relationships=[rel],
+    )
+    model = ModelDescription(title="Demo", description="", entities=[entity])
+
+    # Verify individual string representations
+    assert str(field) == "- **id** (int, mutable): Identifier"
+    assert str(rel) == "- **owner** \u2192 User: Item owner"
+    entity_text = str(entity)
+    assert "## Item" in entity_text
+    assert "### Fields" in entity_text
+    assert str(field) in entity_text
+    assert "### Relationships" in entity_text
+    assert str(rel) in entity_text
+
+    model_text = str(model)
+    assert "# Data Model: Demo" in model_text
+    assert "- [Item](#item)" in model_text
+    assert entity_text in model_text

--- a/tests/test_explore_data_model.py
+++ b/tests/test_explore_data_model.py
@@ -18,8 +18,12 @@ async def test_explore_data_model_returns_summary() -> None:
     summary = await app.resources[tool_name]()
     assert isinstance(summary, DataModelSummary)
     assert summary.title == "My API"
+    assert summary.description == "Demo server"
     assert summary.entity_count == 1
     assert summary.entities == ["Item"]
+    assert isinstance(summary.model, str)
+    assert "Item" in summary.model
+
     summary_text = str(summary)
     assert "# My API" in summary_text
     assert "**Entity count:** 1" in summary_text


### PR DESCRIPTION
## Summary
- keep explore_data_model returning the string model description
- revert `DataModelSummary.model` back to a string
- remove `pragma: no cover` from description `__str__` methods and add tests
- adjust tests for new API and add coverage for description formatting

## Testing
- `pre-commit run --files src/enrichmcp/datamodel.py src/enrichmcp/app.py tests/test_explore_data_model.py tests/test_datamodel_summary.py tests/test_description_str.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686ef14c1494832a99e25fb5f58c6277