### PR TITLE
Improve openai_chat_agent startup message

### DIFF
--- a/examples/openai_chat_agent/app.py
+++ b/examples/openai_chat_agent/app.py
@@ -28,7 +28,9 @@ async def ensure_ollama_running(model: str) -> None:
             "Ollama server not detected. Install from https://ollama.com and "
             "start it using:\n\n"
             "    ollama serve &\n    ollama pull "
-            f"{model}\n"
+            f"{model}\n\n"
+            "Alternatively set the OPENAI_API_KEY environment variable to use "
+            "OpenAI instead of Ollama."
         )
         raise RuntimeError(msg) from None
 


### PR DESCRIPTION
## Summary
- clarify openai_chat_agent instructions when Ollama is unavailable

## Testing
- `make setup`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686f832f74c4832aa1c2b346fc242117