### PR TITLE
Add ToolKind enum and helper method for tool registration

### DIFF
--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -35,6 +35,7 @@ from .parameter import EnrichParameter
 from .relationship import (
     Relationship,
 )
+from .tool import ToolDef, ToolKind
 
 if TYPE_CHECKING:
     from .sqlalchemy import EnrichSQLAlchemyMixin, sqlalchemy_lifespan
@@ -62,6 +63,8 @@ __all__ = [
     "PaginationParams",
     "RedisCache",
     "Relationship",
+    "ToolDef",
+    "ToolKind",
     "__version__",
     "combine_lifespans",
 ]

--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -28,6 +28,7 @@ from .datamodel import DataModelSummary
 from .entity import EnrichModel
 from .parameter import EnrichParameter
 from .relationship import Relationship
+from .tool import ToolDef, ToolKind
 
 # Type variables
 T = TypeVar("T", bound=EnrichModel)
@@ -81,12 +82,17 @@ class EnrichMCP:
         # Register built-in resources
         self._register_builtin_resources()
 
+    def data_model_tool_name(self) -> str:
+        """Return the name of the built-in data model exploration tool."""
+
+        return f"explore_{self.name.lower().replace(' ', '_')}_data_model"
+
     def _register_builtin_resources(self) -> None:
         """
         Register built-in resources for the API.
         """
 
-        tool_name = f"explore_{self.name.lower().replace(' ', '_')}_data_model"
+        tool_name = self.data_model_tool_name()
         tool_description = (
             "IMPORTANT: Call this tool FIRST before using any other tools on the "
             f"{self.title} server. {self.description} "
@@ -370,6 +376,44 @@ class EnrichMCP:
 
         return description
 
+    def _register_tool_def(self, fn: Callable[..., Any], tool_def: ToolDef) -> Callable[..., Any]:
+        """Register ``fn`` as a tool using ``tool_def``."""
+
+        desc = self._append_enrichparameter_hints(tool_def.final_description(self), fn)
+        self.resources[tool_def.name] = fn
+        mcp_tool = self.mcp.tool(name=tool_def.name, description=desc)
+        return mcp_tool(fn)
+
+    def _tool_decorator(
+        self,
+        kind: ToolKind,
+        func: Callable[..., Any] | None = None,
+        *,
+        name: str | None = None,
+        description: str | None = None,
+    ) -> Callable[..., Any] | DecoratorCallable:
+        """Return a decorator that registers a tool of the given ``kind``."""
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            tool_name = name or fn.__name__
+            tool_desc = description or fn.__doc__
+            if not tool_desc:
+                raise ValueError(
+                    f"Resource '{tool_name}' must have a description. "
+                    "Provide it via the decorator or function docstring."
+                )
+
+            if tool_desc == fn.__doc__ and tool_desc:
+                tool_desc = tool_desc.strip()
+
+            tool_def = ToolDef(kind=kind, name=tool_name, description=tool_desc)
+            return self._register_tool_def(fn, tool_def)
+
+        if func is not None:
+            return decorator(func)
+
+        return cast("DecoratorCallable", decorator)
+
     def retrieve(
         self,
         func: Callable[..., Any] | None = None,
@@ -403,37 +447,7 @@ class EnrichMCP:
             ValueError: If no description is provided (neither in decorator nor docstring)
         """
 
-        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-            # Get name and description
-            resource_name = name or fn.__name__
-            resource_desc = description or fn.__doc__
-
-            # Check for description
-            if not resource_desc:
-                raise ValueError(
-                    f"Resource '{resource_name}' must have a description. "
-                    f"Provide it via @app.retrieve(description=...) or function docstring."
-                )
-
-            # Strip docstring if used
-            if resource_desc == fn.__doc__ and resource_desc:
-                resource_desc = resource_desc.strip()
-
-            # Append EnrichParameter parameter hints
-            resource_desc = self._append_enrichparameter_hints(resource_desc, fn)
-
-            # Store the resource for testing
-            self.resources[resource_name] = fn
-            # Create and apply the MCP tool decorator
-            mcp_tool = self.mcp.tool(name=resource_name, description=resource_desc)
-            return mcp_tool(fn)
-
-        # If called without parentheses (@app.retrieve)
-        if func is not None:
-            return decorator(func)
-
-        # If called with parentheses (@app.retrieve())
-        return cast("DecoratorCallable", decorator)
+        return self._tool_decorator(ToolKind.RETRIEVER, func, name=name, description=description)
 
     def resource(self, *args: Any, **kwargs: Any) -> Any:
         """Deprecated alias for :meth:`retrieve`. Use :meth:`retrieve` instead."""
@@ -454,12 +468,7 @@ class EnrichMCP:
     ) -> Callable[..., Any] | DecoratorCallable:
         """Register a create operation."""
 
-        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-            return self.retrieve(fn, name=name, description=description)
-
-        if func is not None:
-            return decorator(func)
-        return cast("DecoratorCallable", decorator)
+        return self._tool_decorator(ToolKind.CREATOR, func, name=name, description=description)
 
     def update(
         self,
@@ -470,12 +479,7 @@ class EnrichMCP:
     ) -> Callable[..., Any] | DecoratorCallable:
         """Register an update operation."""
 
-        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-            return self.retrieve(fn, name=name, description=description)
-
-        if func is not None:
-            return decorator(func)
-        return cast("DecoratorCallable", decorator)
+        return self._tool_decorator(ToolKind.UPDATER, func, name=name, description=description)
 
     def delete(
         self,
@@ -486,12 +490,7 @@ class EnrichMCP:
     ) -> Callable[..., Any] | DecoratorCallable:
         """Register a delete operation."""
 
-        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-            return self.retrieve(fn, name=name, description=description)
-
-        if func is not None:
-            return decorator(func)
-        return cast("DecoratorCallable", decorator)
+        return self._tool_decorator(ToolKind.DELETER, func, name=name, description=description)
 
     def get_context(self) -> EnrichContext:
         """Return the current :class:`EnrichContext` for this app."""

--- a/src/enrichmcp/relationship.py
+++ b/src/enrichmcp/relationship.py
@@ -12,6 +12,8 @@ from typing import (
     get_origin,
 )
 
+from .tool import ToolDef, ToolKind
+
 T = TypeVar("T")
 
 
@@ -98,9 +100,13 @@ class Relationship:
                     f"Get {field_name} for {entity_name}. {self.description}. {func_doc}"
                 ).strip()
 
-                # Register with app's resource system
-                resource_method = self.app.retrieve
-                return resource_method(name=resource_name, description=resource_description)(func)
+                # Register with app's tool system using a ToolDef
+                tool_def = ToolDef(
+                    kind=ToolKind.RESOLVER,
+                    name=resource_name,
+                    description=resource_description,
+                )
+                return self.app._register_tool_def(func, tool_def)
 
             return func
 

--- a/src/enrichmcp/tool.py
+++ b/src/enrichmcp/tool.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - for type checking only
+    from .app import EnrichMCP
+
+
+class ToolKind(str, Enum):
+    """Kinds of MCP tools."""
+
+    RETRIEVER = "retriever"
+    CREATOR = "creator"
+    UPDATER = "updater"
+    DELETER = "deleter"
+    RESOLVER = "resolver"
+
+
+@dataclass
+class ToolDef:
+    """Definition of an MCP tool."""
+
+    kind: ToolKind
+    name: str
+    description: str
+
+    def final_description(self, app: EnrichMCP) -> str:
+        """Return the description with standard usage prefix."""
+        prefix = (
+            f"This is a {self.kind.value} for the {app.title} server. "
+            f"Use it after calling {app.data_model_tool_name()}."
+        )
+        return f"{prefix} {self.description}".strip()

--- a/tests/test_tooldef.py
+++ b/tests/test_tooldef.py
@@ -1,0 +1,51 @@
+from unittest.mock import patch
+
+import pytest
+from pydantic import Field
+
+from enrichmcp import EnrichMCP, EnrichModel, Relationship
+
+
+@pytest.mark.asyncio
+async def test_tool_description_prefixes() -> None:
+    app = EnrichMCP("My API", description="desc")
+
+    with patch.object(app.mcp, "tool", wraps=app.mcp.tool) as mock_tool:
+
+        @app.retrieve(description="get stuff")
+        async def get_stuff() -> dict:
+            return {}
+
+    desc = mock_tool.call_args.kwargs["description"]
+    assert desc.startswith("This is a retriever for the My API server")
+
+    with patch.object(app.mcp, "tool", wraps=app.mcp.tool) as mock_tool:
+
+        @app.create(description="create item")
+        async def create_item() -> bool:
+            return True
+
+    desc = mock_tool.call_args.kwargs["description"]
+    assert desc.startswith("This is a creator for the My API server")
+
+    @app.entity
+    class Item(EnrichModel):
+        """Item."""
+
+        id: int = Field(description="ID")
+
+    @app.entity
+    class User(EnrichModel):
+        """User."""
+
+        id: int = Field(description="ID")
+        items: list[Item] = Relationship(description="items")
+
+    with patch.object(app.mcp, "tool", wraps=app.mcp.tool) as mock_tool:
+
+        @User.items.resolver
+        async def get_items(user_id: int) -> list[Item]:
+            return []
+
+    desc = mock_tool.call_args.kwargs["description"]
+    assert desc.startswith("This is a resolver for the My API server")


### PR DESCRIPTION
## Summary
- introduce `ToolKind` enum and update `ToolDef`
- register tools via `_register_tool_def` and pass `ToolKind`
- add `data_model_tool_name()` helper used by descriptions
- adjust relationship resolver registration

## Testing
- `make setup`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686f7b2d4868832abf4380c545fd1c72