### PR TITLE
Clarify explore_data_model usage

### DIFF
--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -100,22 +100,16 @@ class EnrichMCP:
 
         tool_name = self.data_model_tool_name()
         tool_description = (
-            "IMPORTANT: Call this tool FIRST before using any other tools on the "
-            f"{self.title} server. {self.description} "
-            "This provides a comprehensive overview of the API structure, including "
-            "all entities, their fields, relationships, and semantic meanings. "
-            "Understanding this model is essential for effectively querying and "
-            "navigating the data."
+            "IMPORTANT: Call this tool at the start of an agent session before"
+            f" using other tools on the {self.title} server. {self.description} "
+            "This provides a comprehensive overview of the API structure, including"
+            " all entities, their fields, relationships, and semantic meanings. "
+            "You don't need to call it again if its response is already in context."
         )
 
         @self.retrieve(name=tool_name, description=tool_description)
         async def explore_data_model() -> "DataModelSummary":  # pyright: ignore[reportUnusedFunction]
-            """Get a comprehensive overview of the API data model.
-
-            Returns detailed information about all entities, their fields, relationships,
-            and how to traverse the data graph. Always call this first to understand
-            the available data and operations.
-            """
+            """Return a summary of the API data model."""
             model_description = self.describe_model()
             return DataModelSummary(
                 title=self.title,

--- a/src/enrichmcp/tool.py
+++ b/src/enrichmcp/tool.py
@@ -30,6 +30,7 @@ class ToolDef:
         """Return the description with standard usage prefix."""
         prefix = (
             f"This is a {self.kind.value} for the {app.title} server. "
-            f"Use it after calling {app.data_model_tool_name()}."
+            f"Call {app.data_model_tool_name()} at the start of the session "
+            "and keep its response in context before using this tool."
         )
         return f"{prefix} {self.description}".strip()

--- a/tests/test_explore_data_model.py
+++ b/tests/test_explore_data_model.py
@@ -31,5 +31,5 @@ async def test_explore_data_model_returns_summary() -> None:
 
     tools = await app.mcp.list_tools()
     tool = next(t for t in tools if t.name == tool_name)
-    assert "Call this tool FIRST" in tool.description
+    assert "start of an agent session" in tool.description
     assert "Demo server" in tool.description


### PR DESCRIPTION
## Summary
- update ToolDef description prefix for exploring the data model once per session
- simplify explore_data_model function docstring

## Testing
- `make setup`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686f87cd5144832ab1341e26ed2759b9