### PR TITLE
Use FastMCP context logging

### DIFF
--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -366,6 +366,8 @@ class EnrichMCP:
         self.resources[tool_def.name] = fn
         mcp_tool = self.mcp.tool(name=tool_def.name, description=desc)
 
+        registered = mcp_tool(fn)
+
         sig = inspect.signature(fn)
         context_kwarg = None
         for name, param in sig.parameters.items():
@@ -386,12 +388,12 @@ class EnrichMCP:
                 params = {k: v for k, v in bound.arguments.items() if k != context_kwarg}
                 await ctx.info(f"Calling tool {tool_def.name} params={params!r}")
             if is_coroutine:
-                return await fn(*args, **kwargs)
-            return fn(*args, **kwargs)
+                return await registered(*args, **kwargs)
+            return registered(*args, **kwargs)
 
-        wrapped = functools.wraps(fn)(wrapper)
+        wrapped = functools.wraps(registered)(wrapper)
         wrapped.__signature__ = sig
-        return mcp_tool(wrapped)
+        return wrapped
 
     def _tool_decorator(
         self,

--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -4,6 +4,7 @@ Main application module for enrichmcp.
 Provides the EnrichMCP class for creating MCP applications.
 """
 
+import functools
 import inspect
 import warnings
 from collections.abc import Callable
@@ -364,7 +365,30 @@ class EnrichMCP:
         desc = self._append_enrichparameter_hints(tool_def.final_description(self), fn)
         self.resources[tool_def.name] = fn
         mcp_tool = self.mcp.tool(name=tool_def.name, description=desc)
-        return mcp_tool(fn)
+
+        sig = inspect.signature(fn)
+        context_kwarg = None
+        for param_name, param in sig.parameters.items():
+            try:
+                if issubclass(param.annotation, EnrichContext):
+                    context_kwarg = param_name
+                    break
+            except Exception:
+                continue
+
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            ctx = kwargs.get(context_kwarg) if context_kwarg else None
+            if ctx is not None:
+                params = {k: v for k, v in kwargs.items() if k != context_kwarg}
+                message = f"Calling tool {tool_def.name} params={params!r}"
+                await ctx.info(message)
+            if inspect.iscoroutinefunction(fn):
+                return await fn(*args, **kwargs)
+            return fn(*args, **kwargs)
+
+        wrapped = functools.wraps(fn)(wrapper)
+        wrapped.__signature__ = sig
+        return mcp_tool(wrapped)
 
     def _tool_decorator(
         self,

--- a/tests/test_tool_logging.py
+++ b/tests/test_tool_logging.py
@@ -16,7 +16,7 @@ async def test_tool_logs_call_params():
     mock_ctx = Mock(spec=EnrichContext)
     mock_ctx.info = AsyncMock()
 
-    result = await greet(name="bob", ctx=mock_ctx)
+    result = await greet("bob", ctx=mock_ctx)
 
     assert result == "hi bob"
     mock_ctx.info.assert_awaited_once()

--- a/tests/test_tool_logging.py
+++ b/tests/test_tool_logging.py
@@ -1,0 +1,25 @@
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from enrichmcp import EnrichContext, EnrichMCP
+
+
+@pytest.mark.asyncio
+async def test_tool_logs_call_params():
+    app = EnrichMCP("Test", description="d")
+
+    @app.retrieve(description="say hi")
+    async def greet(name: str, ctx: EnrichContext) -> str:
+        return f"hi {name}"
+
+    mock_ctx = Mock(spec=EnrichContext)
+    mock_ctx.info = AsyncMock()
+
+    result = await greet(name="bob", ctx=mock_ctx)
+
+    assert result == "hi bob"
+    mock_ctx.info.assert_awaited_once()
+    args, kwargs = mock_ctx.info.call_args
+    assert "greet" in args[0]
+    assert "'name': 'bob'" in args[0]


### PR DESCRIPTION
## Summary
- log tool calls with context info
- preserve function signatures when wrapping tools

## Testing
- `pre-commit run --files src/enrichmcp/app.py tests/test_tool_logging.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_686f877b6304832ab1ad0134c9dd3d2a