### PR TITLE
Fix ask_llm context handling

### DIFF
--- a/src/enrichmcp/context.py
+++ b/src/enrichmcp/context.py
@@ -87,7 +87,7 @@ class EnrichContext(Context):  # pyright: ignore[reportMissingTypeArgument]
         """Request LLM sampling via the connected client."""
 
         sampling_messages = self._convert_messages(messages)
-        session = self._request_context.session  # type: ignore[attr-defined]
+        session = self.session
         return await session.create_message(
             messages=sampling_messages,
             system_prompt=system_prompt,

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -44,3 +44,10 @@ async def test_sampling_alias_and_type_error():
     # Invalid message type raises TypeError
     with pytest.raises(TypeError):
         await ctx.sampling([123])
+
+
+@pytest.mark.asyncio
+async def test_ask_llm_requires_request_context():
+    ctx = EnrichContext()
+    with pytest.raises(ValueError, match="outside of a request"):
+        await ctx.ask_llm("ping")


### PR DESCRIPTION
## Summary
- ensure `EnrichContext.ask_llm` uses the public `session` property
- check that calling `ask_llm` without a request raises an error

## Testing
- `make setup`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68716ea90a64832a9ffd86840d19245d