### PR TITLE
Update travel planner instructions

### DIFF
--- a/examples/server_side_llm_travel_planner/README.md
+++ b/examples/server_side_llm_travel_planner/README.md
@@ -18,3 +18,8 @@ python app.py
 Then invoke it with an MCP client such as `mcp_use` or the `openai_chat_agent`
 example. Describe your travel preferences and the server will respond with three
 suggested destinations.
+
+Calling `plan_trip` directly from Python will fail with `Context is not
+available outside of a request`. Always use an MCP client like `mcp_use`
+to create a session and invoke the tool so the request context is properly
+initialized.

--- a/examples/server_side_llm_travel_planner/app.py
+++ b/examples/server_side_llm_travel_planner/app.py
@@ -1,7 +1,5 @@
 """Travel planner example using server-side LLM sampling."""
 
-from __future__ import annotations
-
 import json
 from typing import Annotated
 


### PR DESCRIPTION
## Summary
- remove `__future__` annotations from travel planner example
- document that the `plan_trip` tool must be invoked via an MCP client

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687171a84ae0832a9f937ddc2d368aa8