### PR TITLE
Improve docstrings across EnrichMCP

### DIFF
--- a/src/enrichmcp/cache/__init__.py
+++ b/src/enrichmcp/cache/__init__.py
@@ -26,14 +26,17 @@ class CacheBackend(ABC):
 
     @abstractmethod
     async def get(self, namespace: str, key: str) -> Any | None:
+        """Retrieve a cached value or ``None`` if it does not exist."""
         pass
 
     @abstractmethod
     async def set(self, namespace: str, key: str, value: Any, ttl: int | None = None) -> None:
+        """Store ``value`` in ``namespace`` with optional ``ttl`` in seconds."""
         pass
 
     @abstractmethod
     async def delete(self, namespace: str, key: str) -> bool:
+        """Remove ``key`` from ``namespace``. Returns ``True`` if deleted."""
         pass
 
 
@@ -41,10 +44,12 @@ class MemoryCache(CacheBackend):
     """In-memory cache backend."""
 
     def __init__(self) -> None:
+        """Initialize the in-memory store and a lock for concurrency."""
         self._data: dict[str, dict[str, tuple[Any, float | None]]] = {}
         self._lock = asyncio.Lock()
 
     async def get(self, namespace: str, key: str) -> Any | None:
+        """Return a cached value if present and not expired."""
         async with self._lock:
             ns = self._data.get(namespace)
             if not ns or key not in ns:
@@ -58,11 +63,13 @@ class MemoryCache(CacheBackend):
             return value
 
     async def set(self, namespace: str, key: str, value: Any, ttl: int | None = None) -> None:
+        """Store a value with an optional expiry time."""
         async with self._lock:
             expires = time.monotonic() + ttl if ttl else None
             self._data.setdefault(namespace, {})[key] = (value, expires)
 
     async def delete(self, namespace: str, key: str) -> bool:
+        """Remove a key from the cache."""
         async with self._lock:
             ns = self._data.get(namespace)
             if not ns or key not in ns:
@@ -77,18 +84,22 @@ class RedisCache(CacheBackend):
     """Redis-based cache backend."""
 
     def __init__(self, url: str) -> None:
+        """Create a cache backed by the Redis instance at ``url``."""
         if redis is None:  # pragma: no cover - optional dependency
             raise ImportError("redis package is required for RedisCache")
         self._redis = redis.from_url(url)
 
     async def get(self, namespace: str, key: str) -> Any | None:
+        """Return the cached value stored under ``namespace`` and ``key``."""
         raw = await self._redis.get(f"{namespace}:{key}")
         return pickle.loads(raw) if raw is not None else None
 
     async def set(self, namespace: str, key: str, value: Any, ttl: int | None = None) -> None:
+        """Store ``value`` in Redis with an optional TTL."""
         await self._redis.set(f"{namespace}:{key}", pickle.dumps(value), ex=ttl)
 
     async def delete(self, namespace: str, key: str) -> bool:
+        """Delete a key from Redis and return ``True`` if removed."""
         return await self._redis.delete(f"{namespace}:{key}") > 0
 
 
@@ -99,12 +110,14 @@ class ContextCache:
     """Cache manager bound to a request context."""
 
     def __init__(self, backend: CacheBackend, cache_id: str, request_id: str) -> None:
+        """Create a context-specific cache namespace."""
         self._backend = backend
         self._cache_id = cache_id
         cleaned = re.sub(r"[^a-zA-Z0-9_-]", "_", str(request_id))
         self._request_id = cleaned if cleaned else uuid4().hex
 
     def _user_hash(self) -> str | None:
+        """Return a short hash derived from the current access token."""
         try:
             from mcp.server.auth.middleware.auth_context import get_access_token  # type: ignore
         except Exception:  # pragma: no cover - optional dependency
@@ -115,6 +128,7 @@ class ContextCache:
         return hashlib.sha256(token.token.encode()).hexdigest()[:16]
 
     def _build_namespace(self, scope: str) -> str:
+        """Return a fully-qualified cache namespace for the given scope."""
         if scope == "global":
             return f"enrichmcp:global:{self._cache_id}"
         if scope == "user":
@@ -131,22 +145,27 @@ class ContextCache:
         raise ValueError(f"Unknown cache scope: {scope}")
 
     def _ttl(self, scope: str, ttl: int | None) -> int | None:
+        """Resolve ``ttl`` using defaults for the specified scope."""
         return ttl if ttl is not None else DEFAULT_TTLS.get(scope)
 
     async def get(self, key: str, scope: str = "request") -> Any | None:
+        """Retrieve a cached value for ``key`` within ``scope``."""
         return await self._backend.get(self._build_namespace(scope), key)
 
     async def set(
         self, key: str, value: Any, scope: str = "request", ttl: int | None = None
     ) -> None:
+        """Store ``value`` under ``key`` with an optional ``ttl``."""
         await self._backend.set(self._build_namespace(scope), key, value, self._ttl(scope, ttl))
 
     async def delete(self, key: str, scope: str = "request") -> bool:
+        """Remove ``key`` from the specified ``scope``."""
         return await self._backend.delete(self._build_namespace(scope), key)
 
     async def get_or_set(
         self, key: str, factory: Callable[[], Any], scope: str = "request", ttl: int | None = None
     ) -> Any:
+        """Return cached ``key`` or compute and store it using ``factory``."""
         cached = await self.get(key, scope)
         if cached is not None:
             return cached

--- a/src/enrichmcp/context.py
+++ b/src/enrichmcp/context.py
@@ -42,6 +42,7 @@ class EnrichContext(Context):  # pyright: ignore[reportMissingTypeArgument]
 
     @property
     def cache(self) -> ContextCache:
+        """Access the request-scoped cache."""
         if self._cache is None:
             raise ValueError("Cache is not configured")
         return self._cache

--- a/src/enrichmcp/datamodel.py
+++ b/src/enrichmcp/datamodel.py
@@ -12,6 +12,7 @@ class FieldDescription(BaseModel):
     mutable: bool = False
 
     def __str__(self) -> str:
+        """Return a Markdown bullet describing the field."""
         type_repr = self.type
         if self.mutable and "mutable" not in type_repr:
             type_repr = f"{type_repr}, mutable"
@@ -26,6 +27,7 @@ class RelationshipDescription(BaseModel):
     description: str
 
     def __str__(self) -> str:
+        """Return a Markdown bullet describing the relationship."""
         return f"- **{self.name}** → {self.target}: {self.description}"
 
 
@@ -38,6 +40,7 @@ class EntityDescription(BaseModel):
     relationships: list[RelationshipDescription] = Field(default_factory=list)
 
     def __str__(self) -> str:
+        """Return a Markdown section describing the entity."""
         lines = [f"## {self.name}", self.description, ""]
         if self.fields:
             lines.append("### Fields")
@@ -58,6 +61,7 @@ class ModelDescription(BaseModel):
     entities: list[EntityDescription] = Field(default_factory=list)
 
     def __str__(self) -> str:
+        """Return a Markdown document describing the entire model."""
         lines = [f"# Data Model: {self.title}"]
         if self.description:
             lines.append(self.description)

--- a/src/enrichmcp/entity.py
+++ b/src/enrichmcp/entity.py
@@ -30,6 +30,7 @@ class EnrichModel(BaseModel):
 
     @classmethod
     def relationship_fields(cls) -> set[str]:
+        """Return names of fields that represent relationships."""
         return {k for k, v in cls.model_fields.items() if isinstance(v.default, Relationship)}
 
     @classmethod
@@ -51,6 +52,7 @@ class EnrichModel(BaseModel):
 
     @classmethod
     def relationships(cls) -> set[Relationship]:
+        """Return ``Relationship`` objects declared on the model."""
         return {
             v.default for _, v in cls.model_fields.items() if isinstance(v.default, Relationship)
         }
@@ -173,6 +175,7 @@ class EnrichModel(BaseModel):
         fallback: Callable[[Any], Any] | None = None,
         serialize_as_any: bool = False,
     ) -> str:
+        """Serialize to JSON, omitting relationship fields by default."""
         rel_fields = self.__class__.relationship_fields()
         exclude_set = self.__class__._add_fields_to_incex(exclude, rel_fields)
 
@@ -208,6 +211,7 @@ class EnrichModel(BaseModel):
         fallback: Callable[[Any], Any] | None = None,
         serialize_as_any: bool = False,
     ) -> dict[str, Any]:
+        """Dump the model to a dict while hiding relationship fields."""
         rel_fields = self.__class__.relationship_fields()
         exclude_set = self.__class__._add_fields_to_incex(exclude, rel_fields)
 

--- a/src/enrichmcp/parameter.py
+++ b/src/enrichmcp/parameter.py
@@ -26,4 +26,5 @@ class EnrichParameter:
     metadata: dict[str, Any] = dataclass_field(default_factory=dict)
 
     def __iter__(self) -> Iterable[Any]:  # pragma: no cover - convenience
+        """Iterate over the contained default value to mimic a tuple."""
         yield self.default

--- a/src/enrichmcp/sqlalchemy/auto.py
+++ b/src/enrichmcp/sqlalchemy/auto.py
@@ -17,6 +17,7 @@ from .mixin import EnrichSQLAlchemyMixin
 
 
 def _sa_to_enrich(instance: Any, model_cls: type) -> Any:
+    """Convert a SQLAlchemy instance to its EnrichModel counterpart."""
     data: dict[str, Any] = {}
     for name in model_cls.model_fields:
         if name in model_cls.relationship_fields():
@@ -32,6 +33,7 @@ def _register_default_resources(
     enrich_model: type,
     session_key: str,
 ) -> None:
+    """Register basic list and get resources for ``sa_model``."""
     model_name = sa_model.__name__.lower()
     list_name = f"list_{model_name}s"
     get_name = f"get_{model_name}"
@@ -89,6 +91,7 @@ def _register_relationship_resolvers(
     models: dict[str, type],
     session_key: str,
 ) -> None:
+    """Create default relationship resolvers for ``sa_model``."""
     mapper = inspect(sa_model)
     for rel in mapper.relationships:
         if rel.info.get("exclude"):
@@ -218,7 +221,11 @@ def include_sqlalchemy_models(
     *,
     session_key: str = "session_factory",
 ) -> dict[str, type]:
-    """Register SQLAlchemy models with automatic resources and resolvers."""
+    """Convert and register SQLAlchemy models on ``app``.
+
+    The returned mapping contains both the original SQLAlchemy class names and
+    the generated EnrichModel classes for easy lookup.
+    """
 
     models: dict[str, type] = {}
     for mapper in base.registry.mappers:


### PR DESCRIPTION
## Summary
- add detailed docstrings for cache backends and context cache helpers
- document property access to the request cache
- clarify parameter helper iteration behaviour
- expand entity helper method documentation
- describe datamodel classes and SQLAlchemy utilities more thoroughly

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68717514eed4832aad241b0eb4c964d9