### PR TITLE
Use app.get_context instead of EnrichContext injection

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -58,9 +58,10 @@ class MyContext(EnrichContext):
 
 # Use in resources
 @app.retrieve
-async def get_data(context: MyContext) -> dict:
+async def get_data() -> dict:
+    ctx = app.get_context()
     # Use your custom context
-    return await context.db.fetch_data()
+    return await ctx.db.fetch_data()
 ```
 
-Note: Full context support with dependency injection is planned for future releases.
+Note: Dependency injection is no longer supported; always call ``app.get_context()`` to access the current request context.

--- a/docs/api/parameter.md
+++ b/docs/api/parameter.md
@@ -2,8 +2,7 @@
 
 `EnrichParameter` attaches hints like descriptions and examples to function parameters.
 When a parameter's default value is an instance of `EnrichParameter`, those hints
-are appended to the generated tool description (except for parameters typed as
-`EnrichContext`).
+are appended to the generated tool description.
 
 ```python
 from enrichmcp import EnrichParameter

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -195,8 +195,9 @@ class AppContext(EnrichContext):
 
 
 @app.retrieve
-async def get_customer(customer_id: int, context: AppContext) -> Customer:
+async def get_customer(customer_id: int) -> Customer:
     """Get customer using context."""
+    context = app.get_context()
     # Check cache first
     cached = await context.cache.get(f"customer:{customer_id}")
     if cached:
@@ -249,16 +250,16 @@ The `describe_model()` output will list these allowed values.
 
 ## Context and Lifespan Management
 
-EnrichMCP extends FastMCP's context system to provide automatic injection of logging, progress reporting, and shared resources:
+EnrichMCP extends FastMCP's context system to provide logging, progress reporting, and shared resources.
 
-### Context Injection
+### Accessing Context
 
-Any resource or resolver can receive context by adding a parameter typed as `EnrichContext`:
+Call ``app.get_context()`` inside resources or resolvers to work with the current request context:
 
 ```python
 @app.retrieve
-async def my_resource(param: str, ctx: EnrichContext) -> Result:
-    # Context is automatically injected
+async def my_resource(param: str) -> Result:
+    ctx = app.get_context()
     await ctx.info("Processing request")
     await ctx.report_progress(50, 100)
     return result
@@ -300,7 +301,8 @@ Access lifespan resources through the context:
 
 ```python
 @User.orders.resolver
-async def get_user_orders(user_id: int, ctx: EnrichContext) -> list[Order]:
+async def get_user_orders(user_id: int) -> list[Order]:
+    ctx = app.get_context()
     # Get database from lifespan context
     db = ctx.request_context.lifespan_context["db"]
 
@@ -327,7 +329,8 @@ from enrichmcp.errors import NotFoundError, ValidationError, AuthorizationError
 
 
 @app.retrieve
-async def get_order(order_id: int, context: AppContext) -> Order:
+async def get_order(order_id: int) -> Order:
+    context = app.get_context()
     order = await context.db.get_order(order_id)
 
     if not order:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -153,11 +153,10 @@ if __name__ == "__main__":
 
 ## Using Context
 
-EnrichMCP provides automatic context injection for accessing logging, progress reporting, and lifespan resources:
+Access logging, progress reporting, and lifespan resources through the application context:
 
 ```python
 from contextlib import asynccontextmanager
-from enrichmcp import EnrichContext
 
 
 # Set up lifespan for database connection
@@ -176,7 +175,8 @@ app = EnrichMCP("My API", "Description", lifespan=lifespan)
 
 # Use context in resources and resolvers
 @app.retrieve
-async def get_user(user_id: int, ctx: EnrichContext) -> User:
+async def get_user(user_id: int) -> User:
+    ctx = app.get_context()
     # Logging
     await ctx.info(f"Fetching user {user_id}")
 
@@ -189,7 +189,7 @@ async def get_user(user_id: int, ctx: EnrichContext) -> User:
     return await db.get_user(user_id)
 ```
 
-Context is automatically injected when you add a parameter typed as `EnrichContext`.
+
 
 ## Parameter Hints
 

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -210,8 +210,8 @@ async def get_user_orders(
     user_id: int,
     page: int = 1,
     page_size: int = 10,
-    ctx: EnrichContext
 ) -> PageResult[Order]:
+    ctx = app.get_context()
     """Get user orders with pagination."""
     db = ctx.request_context.lifespan_context["db"]
 

--- a/docs/server_side_llm.md
+++ b/docs/server_side_llm.md
@@ -43,7 +43,8 @@ other resources.
 
 ```python
 @app.retrieve
-async def summarize(text: str, ctx: EnrichContext) -> str:
+async def summarize(text: str) -> str:
+    ctx = app.get_context()
     result = await ctx.ask_llm(
         f"Summarize this: {text}",
         model_preferences=prefer_fast_model(),

--- a/examples/caching/app.py
+++ b/examples/caching/app.py
@@ -3,14 +3,15 @@
 import asyncio
 import random
 
-from enrichmcp import EnrichContext, EnrichMCP
+from enrichmcp import EnrichMCP
 
 app = EnrichMCP("Caching API", description="Demo of request caching")
 
 
 @app.retrieve
-async def slow_square(n: int, ctx: EnrichContext) -> int:
+async def slow_square(n: int) -> int:
     """Return n squared using request-scoped caching."""
+    ctx = app.get_context()
 
     async def compute() -> int:
         await asyncio.sleep(0.1)
@@ -20,8 +21,9 @@ async def slow_square(n: int, ctx: EnrichContext) -> int:
 
 
 @app.retrieve
-async def fibonacci(n: int, ctx: EnrichContext) -> int:
+async def fibonacci(n: int) -> int:
     """Compute the n-th Fibonacci number with global caching."""
+    ctx = app.get_context()
 
     async def compute() -> int:
         await asyncio.sleep(0.1)
@@ -34,8 +36,9 @@ async def fibonacci(n: int, ctx: EnrichContext) -> int:
 
 
 @app.retrieve
-async def user_analytics(ctx: EnrichContext) -> dict:
+async def user_analytics() -> dict:
     """Return fake analytics for the user with user-scoped caching."""
+    ctx = app.get_context()
 
     async def compute() -> dict:
         await asyncio.sleep(0.1)

--- a/examples/server_side_llm_travel_planner/app.py
+++ b/examples/server_side_llm_travel_planner/app.py
@@ -5,7 +5,7 @@ from typing import Annotated
 
 from pydantic import Field
 
-from enrichmcp import EnrichContext, EnrichMCP, EnrichModel, prefer_fast_model
+from enrichmcp import EnrichMCP, EnrichModel, prefer_fast_model
 
 app = EnrichMCP(
     title="Travel Planner",
@@ -60,9 +60,9 @@ def list_destinations() -> list[Destination]:
 @app.retrieve
 async def plan_trip(
     preferences: Annotated[str, Field(description="Your travel preferences")],
-    ctx: EnrichContext,
 ) -> list[Destination]:
     """Return three destinations that best match the given preferences."""
+    ctx = app.get_context()
 
     bullet_list = "\n".join(f"- {d.name}: {d.summary}" for d in DESTINATIONS)
     prompt = (

--- a/examples/shop_api_sqlite/README.md
+++ b/examples/shop_api_sqlite/README.md
@@ -47,13 +47,14 @@ async def lifespan(app: EnrichMCP) -> AsyncIterator[dict[str, Any]]:
     await db.close()
 ```
 
-### Context Injection
+### Accessing Context
 
-Resources and resolvers receive context automatically when they have a parameter typed as `EnrichContext`:
+Call `app.get_context()` inside your resources or resolvers to work with the current request:
 
 ```python
 @app.retrieve
-async def get_user(user_id: int, ctx: EnrichContext) -> User:
+async def get_user(user_id: int) -> User:
+    ctx = app.get_context()
     # Access database from lifespan context
     db = ctx.request_context.lifespan_context["db"]
 

--- a/examples/shop_api_sqlite/app.py
+++ b/examples/shop_api_sqlite/app.py
@@ -14,7 +14,7 @@ from typing import Any
 import aiosqlite
 from pydantic import Field
 
-from enrichmcp import CursorResult, EnrichContext, EnrichMCP, EnrichModel, Relationship
+from enrichmcp import CursorResult, EnrichMCP, EnrichModel, Relationship
 
 
 # Database helper class
@@ -378,8 +378,9 @@ class Order(EnrichModel):
 
 # Define relationship resolvers that use the database
 @User.orders.resolver
-async def by_user_id(user_id: int, ctx: EnrichContext) -> list["Order"]:
+async def by_user_id(user_id: int) -> list["Order"]:
     """Get all orders for a specific user from the database."""
+    ctx = app.get_context()
     # Access the database from the lifespan context
     db: Database = ctx.request_context.lifespan_context["db"]
 
@@ -405,8 +406,9 @@ async def by_user_id(user_id: int, ctx: EnrichContext) -> list["Order"]:
 
 
 @Order.user.resolver
-async def by_order_id(order_id: int, ctx: EnrichContext) -> User:
+async def by_order_id(order_id: int) -> User:
     """Get the user who placed a specific order."""
+    ctx = app.get_context()
     db: Database = ctx.request_context.lifespan_context["db"]
 
     user_row = await db.get_order_user(order_id)
@@ -434,8 +436,9 @@ async def by_order_id(order_id: int, ctx: EnrichContext) -> User:
 
 
 @Order.products.resolver
-async def by_order_id_products(order_id: int, ctx: EnrichContext) -> list[Product]:
+async def by_order_id_products(order_id: int) -> list[Product]:
     """Get all products included in a specific order."""
+    ctx = app.get_context()
     db: Database = ctx.request_context.lifespan_context["db"]
 
     product_rows = await db.get_order_products(order_id)
@@ -459,8 +462,9 @@ async def by_order_id_products(order_id: int, ctx: EnrichContext) -> list[Produc
 
 # Define root resources
 @app.retrieve
-async def list_users(ctx: EnrichContext) -> list[User]:
+async def list_users() -> list[User]:
     """List all users in the system."""
+    ctx = app.get_context()
     db: Database = ctx.request_context.lifespan_context["db"]
 
     user_rows = await db.get_all_users()
@@ -483,8 +487,9 @@ async def list_users(ctx: EnrichContext) -> list[User]:
 
 
 @app.retrieve
-async def get_user(user_id: int, ctx: EnrichContext) -> User:
+async def get_user(user_id: int) -> User:
     """Get a specific user by ID."""
+    ctx = app.get_context()
     db: Database = ctx.request_context.lifespan_context["db"]
 
     user_row = await db.get_user(user_id)
@@ -511,8 +516,9 @@ async def get_user(user_id: int, ctx: EnrichContext) -> User:
 
 
 @app.retrieve
-async def list_products(ctx: EnrichContext) -> list[Product]:
+async def list_products() -> list[Product]:
     """List all products in the catalog."""
+    ctx = app.get_context()
     db: Database = ctx.request_context.lifespan_context["db"]
 
     product_rows = await db.get_all_products()
@@ -536,9 +542,10 @@ async def list_products(ctx: EnrichContext) -> list[Product]:
 
 @app.retrieve
 async def list_orders(
-    ctx: EnrichContext, status: str | None = None, cursor: str | None = None, limit: int = 10
+    status: str | None = None, cursor: str | None = None, limit: int = 10
 ) -> CursorResult[Order]:
     """List orders, optionally filtered by status."""
+    ctx = app.get_context()
     db: Database = ctx.request_context.lifespan_context["db"]
 
     order_rows, next_cursor = await db.get_all_orders(status, cursor, limit)


### PR DESCRIPTION
## Summary
- update docs and examples to remove EnrichContext parameter injection
- demonstrate accessing context with `app.get_context()`

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68744d770bf0832aa14bdf4b72202223