### PR TITLE
Improve cache and SQLAlchemy coverage

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@
 pytest>=8.0.0
 pytest-asyncio>=1.0.0
 pytest-cov>=5.0.0
+fakeredis>=2.0.0
 
 # MCP client utilities used by example tests
 mcp_use>=1.0.0

--- a/src/enrichmcp/cache/__init__.py
+++ b/src/enrichmcp/cache/__init__.py
@@ -76,7 +76,22 @@ class MemoryCache(CacheBackend):
 class RedisCache(CacheBackend):
     """Redis-based cache backend."""
 
-    def __init__(self, url: str) -> None:
+    def __init__(self, url: str, redis_client: Any | None = None) -> None:
+        """Initialize the cache.
+
+        Parameters
+        ----------
+        url:
+            Redis connection URL. Ignored if ``redis_client`` is provided.
+        redis_client:
+            Optional pre-configured redis client. Allows injecting a fake
+            instance such as ``fakeredis`` for tests without monkeypatching.
+        """
+
+        if redis_client is not None:
+            self._redis = redis_client
+            return
+
         if redis is None:  # pragma: no cover - optional dependency
             raise ImportError("redis package is required for RedisCache")
         self._redis = redis.from_url(url)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -56,3 +56,36 @@ async def test_request_id_sanitization_and_unique_fallback():
     c1 = ContextCache(backend, "app", "")
     c2 = ContextCache(backend, "app", "")
     assert c1._request_id != c2._request_id
+
+
+@pytest.mark.asyncio
+async def test_redis_cache_basic():
+    import fakeredis.aioredis
+
+    from enrichmcp.cache import RedisCache
+
+    fake = fakeredis.aioredis.FakeRedis()
+    rc = RedisCache("redis://", redis_client=fake)
+
+    await rc.set("ns", "k", "v")
+    assert await rc.get("ns", "k") == "v"
+    assert await rc.delete("ns", "k") is True
+    assert await rc.get("ns", "k") is None
+
+
+def test_context_cache_ttl():
+    backend = MemoryCache()
+    cache = ContextCache(backend, "app", "req")
+    assert cache._ttl("global", None) == 3600
+    assert cache._ttl("user", 10) == 10
+
+
+def test_build_namespace_and_ttl(monkeypatch):
+    cache = ContextCache(MemoryCache(), "app", "req")
+    monkeypatch.setattr(cache, "_user_hash", lambda: "u1")
+    assert cache._build_namespace("global") == "enrichmcp:global:app"
+    assert cache._build_namespace("user") == "enrichmcp:user:app:u1"
+    assert cache._build_namespace("request").startswith("enrichmcp:request:app:")
+    with pytest.raises(ValueError):
+        cache._build_namespace("bad")
+    assert cache._ttl("unknown", None) is None

--- a/tests/test_context_extras.py
+++ b/tests/test_context_extras.py
@@ -1,0 +1,8 @@
+from enrichmcp.context import prefer_fast_model, prefer_smart_model
+
+
+def test_prefer_fast_and_smart_models():
+    fast = prefer_fast_model()
+    smart = prefer_smart_model()
+    assert fast.speedPriority > fast.costPriority
+    assert smart.intelligencePriority > smart.speedPriority

--- a/tests/test_sqlalchemy_single_rel.py
+++ b/tests/test_sqlalchemy_single_rel.py
@@ -1,0 +1,64 @@
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import ForeignKey
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from enrichmcp import EnrichContext, EnrichMCP
+from enrichmcp.sqlalchemy import (
+    EnrichSQLAlchemyMixin,
+    include_sqlalchemy_models,
+    sqlalchemy_lifespan,
+)
+
+
+class Base(DeclarativeBase, EnrichSQLAlchemyMixin):
+    pass
+
+
+class User(Base):
+    __tablename__ = "users"
+    id: Mapped[int] = mapped_column(primary_key=True, info={"description": "ID"})
+    name: Mapped[str] = mapped_column(info={"description": "Name"})
+    order: Mapped["Order"] = relationship(
+        back_populates="user", uselist=False, info={"description": "Order"}
+    )
+
+
+class Order(Base):
+    __tablename__ = "orders"
+    id: Mapped[int] = mapped_column(primary_key=True, info={"description": "ID"})
+    user_id: Mapped[int] = mapped_column(ForeignKey("users.id"))
+    user: Mapped[User] = relationship(back_populates="order", info={"description": "User"})
+
+
+async def seed(session: AsyncSession) -> None:
+    user = User(id=1, name="Bob")
+    order = Order(id=1, user=user)
+    session.add_all([user, order])
+
+
+def create_app():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    lifespan = sqlalchemy_lifespan(Base, engine, seed=seed)
+    app = EnrichMCP("Test", "Desc", lifespan=lifespan)
+    include_sqlalchemy_models(app, Base)
+    return app, lifespan
+
+
+@pytest.mark.asyncio
+async def test_single_relationship_resolver():
+    app, lifespan = create_app()
+    async with lifespan(app) as ctx:
+        sf = ctx["session_factory"]
+        mctx = Mock(spec=EnrichContext)
+        mctx.request_context = Mock(lifespan_context={"session_factory": sf})
+        resolver = app.resources["get_orderenrichmodel_user"]
+        user = await resolver(order_id=1, ctx=mctx)
+        assert user.name == "Bob"
+        none = await resolver(order_id=99, ctx=mctx)
+        assert none is None
+        # via kwargs dict
+        again = await resolver(ctx=mctx, kwargs={"order_id": 1})
+        assert again.name == "Bob"

--- a/uv.lock
+++ b/uv.lock
@@ -24,8 +24,6 @@ babel==2.17.0
     # via mkdocs-material
 backoff==2.2.1
     # via posthog
-backports-tarfile==1.2.0
-    # via jaraco-context
 backrefs==5.8
     # via mkdocs-material
 build==1.2.2.post1
@@ -61,6 +59,8 @@ distro==1.9.0
     # via posthog
 docutils==0.21.2
     # via readme-renderer
+fakeredis==2.30.1
+    # via -r requirements-dev.txt
 filelock==3.18.0
     # via virtualenv
 frozenlist==1.7.0
@@ -97,8 +97,6 @@ idna==3.10
     #   httpx
     #   requests
     #   yarl
-importlib-metadata==8.7.0
-    # via keyring
 iniconfig==2.1.0
     # via pytest
 jaraco-classes==3.4.0
@@ -311,6 +309,8 @@ pyyaml-env-tag==1.1
     # via mkdocs
 readme-renderer==44.0
     # via twine
+redis==6.2.0
+    # via fakeredis
 requests==2.32.4
     # via
     #   id
@@ -343,6 +343,8 @@ six==1.17.0
     #   python-dateutil
 sniffio==1.3.1
     # via anyio
+sortedcontainers==2.4.0
+    # via fakeredis
 sqlalchemy==2.0.41
     # via
     #   -r requirements-dev.txt
@@ -396,7 +398,5 @@ wheel==0.45.1
     # via -r requirements-dev.txt
 yarl==1.20.1
     # via aiohttp
-zipp==3.23.0
-    # via importlib-metadata
 zstandard==0.23.0
     # via langsmith


### PR DESCRIPTION
## Summary
- test RedisCache behavior with fakeredis
- remove unused context cache error test
- allow injecting a redis client when instantiating RedisCache
- include fakeredis in dev dependencies
- update lock file

## Testing
- `pre-commit run --files uv.lock requirements-dev.txt src/enrichmcp/cache/__init__.py tests/test_cache.py tests/test_context_extras.py tests/test_sqlalchemy_single_rel.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687174df5d30832aae5de5657f243ff1