### PR TITLE
Finalize sampling callback

### DIFF
--- a/examples/openai_chat_agent/app.py
+++ b/examples/openai_chat_agent/app.py
@@ -7,26 +7,66 @@ conversation context using the agent's built-in memory.
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
+from importlib import metadata
+from typing import TYPE_CHECKING
 
 import httpx
 from dotenv import load_dotenv
+from langchain_core.messages import AIMessage, HumanMessage, SystemMessage
 from langchain_ollama import ChatOllama
 from langchain_openai import ChatOpenAI
-from mcp.types import CreateMessageRequestParams, CreateMessageResult, ErrorData, TextContent
+from mcp.types import (
+    CreateMessageRequestParams,
+    CreateMessageResult,
+    ErrorData,
+    TextContent,
+)
 from mcp_use import MCPAgent, MCPClient, load_config_file
+from packaging.version import Version
+
+if TYPE_CHECKING:  # pragma: no cover - only for type hints
+    from mcp import ClientSession
+
+logger = logging.getLogger(__name__)
 
 SYSTEM_MESSAGE = "You are a helpful assistant that talks to the user and uses tools via MCP."
 
 
-async def sampling_callback(
-    context: ClientSession, params: CreateMessageRequestParams
-) -> CreateMessageResult | ErrorData:
-    return CreateMessageResult(
-        content=TextContent(text='["Cape Town"]', type="text"),
-        model="gpt-4o-mini",
-        role="assistant",
-    )
+def make_sampling_callback(llm: ChatOpenAI | ChatOllama):
+    async def sampling_callback(
+        context: ClientSession, params: CreateMessageRequestParams
+    ) -> CreateMessageResult | ErrorData:
+        lc_messages = []
+        if params.system_prompt:
+            lc_messages.append(SystemMessage(content=params.system_prompt))
+        for msg in params.messages:
+            content = msg.content.text
+            if msg.role == "assistant":
+                lc_messages.append(AIMessage(content=content))
+            else:
+                lc_messages.append(HumanMessage(content=content))
+
+        try:
+            result_msg = await llm.ainvoke(
+                lc_messages,
+                temperature=params.temperature,
+                max_tokens=params.max_tokens,
+                stop=params.stop_sequences,
+            )
+        except Exception as exc:  # pragma: no cover - runtime error handling
+            return ErrorData(code=400, message=str(exc))
+
+        text = getattr(result_msg, "content", str(result_msg))
+        model_name = getattr(llm, "model", "llm")
+        return CreateMessageResult(
+            content=TextContent(text=text, type="text"),
+            model=model_name,
+            role="assistant",
+        )
+
+    return sampling_callback
 
 
 async def ensure_ollama_running(model: str) -> None:
@@ -51,17 +91,32 @@ async def run_memory_chat() -> None:
     load_dotenv()
     config_file = os.path.join(os.path.dirname(__file__), "config.json")
 
-    print("Initializing chat...")
-    client = MCPClient(load_config_file(config_file), sampling_callback=sampling_callback)
-
     openai_key = os.getenv("OPENAI_API_KEY")
     ollama_model = os.getenv("OLLAMA_MODEL", "llama3.2")
+
+    print("Initializing chat...")
 
     if openai_key:
         llm = ChatOpenAI(model="gpt-4o")
     else:
         await ensure_ollama_running(ollama_model)
         llm = ChatOllama(model=ollama_model)
+
+    sampling_cb = make_sampling_callback(llm)
+
+    try:
+        mcp_use_version = metadata.version("mcp_use")
+    except metadata.PackageNotFoundError:  # pragma: no cover - dev env only
+        mcp_use_version = "0"
+
+    if Version(mcp_use_version) > Version("1.3.7"):
+        client = MCPClient(
+            load_config_file(config_file),
+            sampling_callback=sampling_cb,
+        )
+    else:
+        logger.warning("mcp-use %s does not support sampling, disabling callback", mcp_use_version)
+        client = MCPClient(load_config_file(config_file))
 
     agent = MCPAgent(
         llm=llm,

--- a/examples/server_side_llm_travel_planner/app.py
+++ b/examples/server_side_llm_travel_planner/app.py
@@ -69,7 +69,6 @@ async def plan_trip(
         "given preferences. Reply with a JSON list of names only.\nPreferences: "
         f"{preferences}\n\n{bullet_list}"
     )
-    app.get_context()
     result = await app.get_context().ask_llm(
         prompt,
         model_preferences=prefer_fast_model(),


### PR DESCRIPTION
## Summary
- improve `openai_chat_agent` example
  - add real sampling callback using ChatGPT or Ollama
  - add version check to only register callback when `mcp_use` supports it
- clean up travel planner example

## Testing
- `make setup`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_687482a36520832a8b9e3cb0acb647d4