### PR TITLE
Add ask_user support

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -40,6 +40,22 @@ result = await ctx.ask_llm(
 print(result.content.text)
 ```
 
+## User Elicitation
+
+Call `ask_user()` when you need additional input from the client. It wraps the
+underlying MCP `elicit()` API:
+
+```python
+class BookingPreferences(BaseModel):
+    alternativeDate: str | None
+    checkAlternative: bool = False
+
+result = await ctx.ask_user(
+    message="No tables available. Try another date?",
+    schema=BookingPreferences,
+)
+```
+
 ## Extending Context
 
 For now, if you need context functionality, you can extend the base class:

--- a/src/enrichmcp/context.py
+++ b/src/enrichmcp/context.py
@@ -6,6 +6,7 @@ Provides a thin wrapper over FastMCP's Context for request handling.
 
 from typing import Literal
 
+from mcp.server.elicitation import ElicitationResult, ElicitSchemaModelT
 from mcp.server.fastmcp import Context  # pyright: ignore[reportMissingTypeArgument]
 from mcp.types import (
     CreateMessageResult,
@@ -106,6 +107,15 @@ class EnrichContext(Context):  # pyright: ignore[reportMissingTypeArgument]
         """Alias for :meth:`ask_llm`."""
 
         return await self.ask_llm(messages, **kwargs)
+
+    async def ask_user(
+        self,
+        message: str,
+        schema: type[ElicitSchemaModelT],
+    ) -> ElicitationResult:
+        """Interactively ask the client for input using MCP elicitation."""
+
+        return await super().elicit(message=message, schema=schema)
 
 
 def prefer_fast_model() -> ModelPreferences:

--- a/tests/test_elicitation.py
+++ b/tests/test_elicitation.py
@@ -1,0 +1,28 @@
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from pydantic import BaseModel
+
+from enrichmcp import EnrichContext
+
+
+class Prefs(BaseModel):
+    choice: bool
+
+
+@pytest.mark.asyncio
+async def test_ask_user_delegates_to_context_elicit():
+    ctx = EnrichContext.model_construct(_request_context=Mock())
+
+    with patch("enrichmcp.context.Context.elicit", AsyncMock(return_value="ok")) as mock:
+        got = await ctx.ask_user("hi", Prefs)
+        assert got == "ok"
+        mock.assert_awaited_once_with(message="hi", schema=Prefs)
+
+
+@pytest.mark.asyncio
+async def test_ask_user_requires_request_context():
+    ctx = EnrichContext()
+
+    with pytest.raises(ValueError, match="outside of a request"):
+        await ctx.ask_user("hi", Prefs)


### PR DESCRIPTION
## Summary
- upgrade `mcp` to latest for `Context.elicit`
- add `ask_user` wrapper on `EnrichContext`
- document elicitation in context docs
- test new API

## Testing
- `pre-commit run --files tests/test_elicitation.py src/enrichmcp/context.py docs/api/context.md`
- `pytest -q tests/test_elicitation.py`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68748cba8d4c832aa7936d2445262228