### PR TITLE
Fix LLM callback param names

### DIFF
--- a/examples/openai_chat_agent/app.py
+++ b/examples/openai_chat_agent/app.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from mcp import ClientSession
 
 logger = logging.getLogger(__name__)
+logging.basicConfig(level=logging.INFO)
 
 SYSTEM_MESSAGE = "You are a helpful assistant that talks to the user and uses tools via MCP."
 
@@ -39,10 +40,10 @@ def make_sampling_callback(llm: ChatOpenAI | ChatOllama):
         context: ClientSession, params: CreateMessageRequestParams
     ) -> CreateMessageResult | ErrorData:
         lc_messages = []
-        if params.systemPrompt:
-            lc_messages.append(SystemMessage(content=params.systemPrompt))
+        system_prompt = getattr(params, "systemPrompt", None)
+        if system_prompt:
+            lc_messages.append(SystemMessage(content=system_prompt))
         for msg in params.messages:
-            logger.error(f"HERE2")
             content = msg.content.text
             if msg.role == "assistant":
                 lc_messages.append(AIMessage(content=content))
@@ -50,12 +51,14 @@ def make_sampling_callback(llm: ChatOpenAI | ChatOllama):
                 lc_messages.append(HumanMessage(content=content))
 
         try:
-            logger.error(f'Sampling with messages: {lc_messages}')
+            logger.info(f"Sampling with messages: {lc_messages}")
+            max_tokens = getattr(params, "maxTokens", None)
+            stop_sequences = getattr(params, "stopSequences", None)
             result_msg = await llm.ainvoke(
                 lc_messages,
                 temperature=params.temperature,
-                max_tokens=params.maxTokens,
-                stop=params.stopSequences,
+                max_tokens=max_tokens,
+                stop=stop_sequences,
             )
         except Exception as exc:
             logger.error(f"Failed to invoke llm for sampling: {exc}")
@@ -63,7 +66,7 @@ def make_sampling_callback(llm: ChatOpenAI | ChatOllama):
 
         text = getattr(result_msg, "content", str(result_msg))
         model_name = getattr(llm, "model", "llm")
-        logger.error(f'Sampling result: {text}')
+        logger.info(f"Sampling result: {text}")
         return CreateMessageResult(
             content=TextContent(text=text, type="text"),
             model=model_name,
@@ -117,7 +120,10 @@ async def run_memory_chat() -> None:
             sampling_callback=make_sampling_callback(llm),
         )
     else:
-        logger.warning("mcp-use %s does not support sampling, install >1.3.6. Disabling sampling callback", mcp_use_version)
+        logger.warning(
+            "mcp-use %s does not support sampling, install >1.3.6. Disabling sampling callback",
+            mcp_use_version,
+        )
         client = MCPClient(load_config_file(config_file))
 
     agent = MCPAgent(

--- a/examples/server_side_llm_travel_planner/app.py
+++ b/examples/server_side_llm_travel_planner/app.py
@@ -66,7 +66,10 @@ async def plan_trip(
     bullet_list = "\n".join(f"- {d.name}: {d.summary}" for d in DESTINATIONS)
     prompt = (
         "Select the three best destinations from the list below based on the "
-        "given preferences. Reply with a JSON list of names only. The text should be directly parsable with json.loads in Python. Do NOT add ```json like markdown. Example response:\n[\"San Francisco\"]\n\n\nPreferences: "
+        "given preferences. Reply with a JSON list of names only. "
+        "The text should be directly parsable with json.loads in Python. "
+        'Do NOT add ```json like markdown. Example response:\n["San Francisco"]'
+        "\n\n\nPreferences: "
         f"{preferences}\n\n{bullet_list}"
     )
     result = await app.get_context().ask_llm(


### PR DESCRIPTION
## Summary
- remove snake_case fallbacks in `openai_chat_agent`
- rely on the new MCP fields
- fix linter warning in travel planner example
- log sampling details at INFO level

## Testing
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68748f38d378832a814c90e551e854e8