### PR TITLE
Add interactive example selection

### DIFF
--- a/examples/openai_chat_agent/README.md
+++ b/examples/openai_chat_agent/README.md
@@ -11,4 +11,6 @@ cp .env.example .env  # set OPENAI_API_KEY or adjust OLLAMA_MODEL
 uv run app.py
 ```
 
-`config.json` points to the `shop_api` example so everything runs locally by default. If `OPENAI_API_KEY` is not provided the agent uses the model specified by `OLLAMA_MODEL` (default `llama3`). An Ollama server must be running when using this mode.
+Running `app.py` will display the available examples and let you choose which one to start. You can also provide `--example <name>` to skip the prompt.
+
+If `OPENAI_API_KEY` is not provided the agent uses the model specified by `OLLAMA_MODEL` (default `llama3`). An Ollama server must be running when using this mode.


### PR DESCRIPTION
## Summary
- allow choosing an example at runtime in `openai_chat_agent`
- mention the new `--example` option in README

## Testing
- `make setup`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874ae405e50832a94d4ceaf2ba2d268