### PR TITLE
Add balanced model preferences

### DIFF
--- a/docs/api/context.md
+++ b/docs/api/context.md
@@ -30,7 +30,7 @@ user, or global scopes.
 Use `ask_llm()` (or the `sampling()` alias) to request completions from the client-side LLM. See the [Server-Side LLM guide](../server_side_llm.md) for more details:
 
 ```python
-from enrichmcp import prefer_fast_model
+from enrichmcp import prefer_fast_model, prefer_medium_model, prefer_smart_model
 
 result = await ctx.ask_llm(
     "Summarize our latest sales numbers",

--- a/docs/server_side_llm.md
+++ b/docs/server_side_llm.md
@@ -16,7 +16,7 @@ tuning parameters.
 | `system_prompt` | Optional system prompt that defines overall behavior. |
 | `max_tokens` | Maximum number of tokens the client should generate. Defaults to 1000. |
 | `temperature` | Sampling temperature for controlling randomness. |
-| `model_preferences` | `ModelPreferences` object describing cost, speed and intelligence priorities. Use `prefer_fast_model()` or `prefer_smart_model()` as shortcuts. |
+| `model_preferences` | `ModelPreferences` object describing cost, speed and intelligence priorities. Use `prefer_fast_model()`, `prefer_medium_model()` or `prefer_smart_model()` as shortcuts. |
 | `allow_tools` | Controls what tools the LLM can see: `"none"`, `"thisServer"`, or `"allServers"`. |
 | `stop_sequences` | Strings that stop generation when encountered. |
 
@@ -27,11 +27,11 @@ speed or intelligence when the client chooses an LLM. Two convenience functions
 are provided:
 
 ```python
-from enrichmcp import prefer_fast_model, prefer_smart_model
+from enrichmcp import prefer_fast_model, prefer_medium_model, prefer_smart_model
 ```
 
-Use `prefer_fast_model()` when low latency and price are most important. Use
-`prefer_smart_model()` when you need the best reasoning capability.
+Use `prefer_fast_model()` when low latency and price are most important.
+`prefer_medium_model()` offers balanced quality and cost. Use `prefer_smart_model()` when you need the best reasoning capability.
 
 ### Tool Access
 

--- a/src/enrichmcp/__init__.py
+++ b/src/enrichmcp/__init__.py
@@ -31,6 +31,7 @@ from .cache import MemoryCache, RedisCache
 from .context import (
     EnrichContext,
     prefer_fast_model,
+    prefer_medium_model,
     prefer_smart_model,
 )
 from .datamodel import (
@@ -85,6 +86,7 @@ __all__ = [
     "__version__",
     "combine_lifespans",
     "prefer_fast_model",
+    "prefer_medium_model",
     "prefer_smart_model",
 ]
 

--- a/src/enrichmcp/context.py
+++ b/src/enrichmcp/context.py
@@ -120,13 +120,32 @@ class EnrichContext(Context):  # pyright: ignore[reportMissingTypeArgument]
 
 
 def prefer_fast_model() -> ModelPreferences:
-    """Model preferences optimized for speed and cost."""
+    """Model preferences optimized for speed and cost using small models."""
 
     return ModelPreferences(
-        hints=[ModelHint(name="gpt-4o-mini"), ModelHint(name="claude-3-haiku")],
+        hints=[
+            ModelHint(name="gpt-4o-mini-20240613"),
+            ModelHint(name="claude-3-haiku-20240307"),
+            ModelHint(name="llama-3-8b"),
+        ],
         costPriority=0.8,
         speedPriority=0.9,
         intelligencePriority=0.3,
+    )
+
+
+def prefer_medium_model() -> ModelPreferences:
+    """Balanced model preferences for general use."""
+
+    return ModelPreferences(
+        hints=[
+            ModelHint(name="gpt-4o-2024-05-13"),
+            ModelHint(name="claude-3-sonnet-20240229"),
+            ModelHint(name="llama-3-70b"),
+        ],
+        costPriority=0.5,
+        speedPriority=0.6,
+        intelligencePriority=0.6,
     )
 
 
@@ -134,7 +153,11 @@ def prefer_smart_model() -> ModelPreferences:
     """Model preferences optimized for intelligence and capability."""
 
     return ModelPreferences(
-        hints=[ModelHint(name="gpt-4o"), ModelHint(name="claude-3-opus")],
+        hints=[
+            ModelHint(name="o3"),
+            ModelHint(name="claude-3-opus-20240229"),
+            ModelHint(name="llama-3-405b"),
+        ],
         costPriority=0.2,
         speedPriority=0.3,
         intelligencePriority=0.9,

--- a/tests/test_context_extras.py
+++ b/tests/test_context_extras.py
@@ -1,8 +1,15 @@
-from enrichmcp.context import prefer_fast_model, prefer_smart_model
+from enrichmcp.context import (
+    prefer_fast_model,
+    prefer_medium_model,
+    prefer_smart_model,
+)
 
 
-def test_prefer_fast_and_smart_models():
+def test_model_preference_helpers():
     fast = prefer_fast_model()
+    medium = prefer_medium_model()
     smart = prefer_smart_model()
+
     assert fast.speedPriority > fast.costPriority
+    assert medium.speedPriority > medium.costPriority
     assert smart.intelligencePriority > smart.speedPriority


### PR DESCRIPTION
## Summary
- extend model preference utilities to include llama models and modern model names
- add new `prefer_medium_model` helper
- document the new helper and updated examples
- adjust unit tests for the three preference helpers

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874b01f1c0c832abf6be4e9f7c38844