### PR TITLE
Add changelog for v0.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.7] - 2025-07-14
+
+### Added
+- Server-side LLM sampling via `ask_llm()` with new `ask_user()` helper.
+- `prefer_medium_model()` for balanced model selection.
+- Expanded examples and tests including Redis cache and travel planner.
+
+### Changed
+- Removed automatic `EnrichContext` injection; use `app.get_context()`.
+- Improved chat agent and memory examples.
+
+### Fixed
+- Correct context usage in examples and `ask_llm` helper.
 ## [0.4.6] - 2025-07-10
 
 ### Added


### PR DESCRIPTION
## Summary
- document v0.4.7 release in CHANGELOG

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6874b84129a8832ab9c152cbd21db4ef