### PR TITLE
Fix model rebuilds for forward refs

### DIFF
--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -88,6 +88,11 @@ class EnrichMCP:
         # Register built-in resources
         self._register_builtin_resources()
 
+    def rebuild_models(self) -> None:
+        """Rebuild all registered models to resolve forward references."""
+        for entity_cls in self.entities.values():
+            entity_cls.model_rebuild()
+
     def data_model_tool_name(self) -> str:
         """Return the name of the built-in data model exploration tool."""
 
@@ -515,6 +520,10 @@ class EnrichMCP:
                 f"The following relationships are missing resolvers: {', '.join(unresolved)}. "
                 f"Define resolvers with @Entity.relationship.resolver"
             )
+
+        # Resolve any forward references now that all entities are registered
+        for entity_cls in self.entities.values():
+            entity_cls.model_rebuild()
 
         # Forward transport options to FastMCP
         if transport is not None:

--- a/src/enrichmcp/relationship.py
+++ b/src/enrichmcp/relationship.py
@@ -106,7 +106,12 @@ class Relationship:
                     name=resource_name,
                     description=resource_description,
                 )
-                return self.app._register_tool_def(func, tool_def)
+                try:
+                    return self.app._register_tool_def(func, tool_def)
+                except Exception:
+                    if hasattr(self.app, "rebuild_models"):
+                        self.app.rebuild_models()
+                    return self.app._register_tool_def(func, tool_def)
 
             return func
 


### PR DESCRIPTION
## Summary
- ensure all entities rebuild with forward references before starting the server
- fallback to rebuilding models when registering resolvers fails

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_68795d88f2d8832ab445e0062e9f9b8f