### PR TITLE
Add prompt wrapper

### DIFF
--- a/src/enrichmcp/app.py
+++ b/src/enrichmcp/app.py
@@ -473,6 +473,16 @@ class EnrichMCP:
 
         return self._tool_decorator(ToolKind.DELETER, func, name=name, description=description)
 
+    def prompt(
+        self,
+        name: str | None = None,
+        title: str | None = None,
+        description: str | None = None,
+    ) -> Callable[[F], F]:
+        """Register a prompt via the underlying :class:`FastMCP` instance."""
+
+        return self.mcp.prompt(name=name, title=title, description=description)
+
     def get_context(self) -> EnrichContext:
         """Return the current :class:`EnrichContext` for this app."""
 

--- a/tests/test_prompt.py
+++ b/tests/test_prompt.py
@@ -1,0 +1,17 @@
+from unittest.mock import Mock
+
+from enrichmcp import EnrichMCP
+
+
+def test_prompt_delegates_to_fastmcp():
+    app = EnrichMCP("Title", description="desc")
+    decorator = Mock(side_effect=lambda f: f)
+    app.mcp.prompt = Mock(return_value=decorator)
+
+    @app.prompt(name="foo", title="Foo", description="bar")
+    def fn():
+        pass
+
+    app.mcp.prompt.assert_called_once_with(name="foo", title="Foo", description="bar")
+    decorator.assert_called_once_with(fn)
+    assert fn.__name__ == "fn"


### PR DESCRIPTION
## Summary
- wrap `FastMCP.prompt` via `EnrichMCP.prompt`
- test that prompt calls the underlying FastMCP implementation

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_687c5ff1ac24832ab5f8656a024f02d5