### PR TITLE
fix: adapt to FastMCP instructions parameter

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -10,7 +10,7 @@ The main application class that manages entities, relationships, and resources.
 ```python
 from enrichmcp import EnrichMCP
 
-app = EnrichMCP(title="My API", description="API for AI agents")
+app = EnrichMCP(title="My API", instructions="API for AI agents")
 ```
 
 ### [EnrichModel](api/entity.md)

--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -11,19 +11,19 @@ The `EnrichMCP` class is the main entry point for creating an enrichmcp applicat
 
 ## Class Reference
 
-### `EnrichMCP(title: str, description: str)`
+### `EnrichMCP(title: str, instructions: str)`
 
 Creates a new enrichmcp application.
 
 **Parameters:**
 - `title`: The name of your API
-- `description`: A description of what your API provides
+- `instructions`: Instructions for interacting with your API
 
 **Example:**
 ```python
 from enrichmcp import EnrichMCP
 
-app = EnrichMCP(title="My API", description="API for AI agents to access my data")
+app = EnrichMCP(title="My API", instructions="API for AI agents to access my data")
 ```
 
 ## Methods
@@ -120,7 +120,7 @@ async def custom_tool(x: int) -> int:
 Return the current request context as an :class:`~enrichmcp.EnrichContext`.
 
 ```python
-app = EnrichMCP("My API", description="desc")
+app = EnrichMCP("My API", instructions="desc")
 ctx = app.get_context()
 assert ctx.fastmcp is app.mcp
 ```
@@ -208,7 +208,7 @@ from enrichmcp import EnrichMCP, EnrichModel, Relationship
 from pydantic import Field
 
 # Create app
-app = EnrichMCP(title="Bookstore API", description="API for managing books and authors")
+app = EnrichMCP(title="Bookstore API", instructions="API for managing books and authors")
 
 
 # Define entities

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -12,7 +12,7 @@ from enrichmcp import EnrichMCP, EnrichModel, Relationship
 from pydantic import Field
 
 # Create the application
-app = EnrichMCP(title="Book Catalog API", description="A simple book catalog for AI agents")
+app = EnrichMCP(title="Book Catalog API", instructions="A simple book catalog for AI agents")
 
 
 # Define entities
@@ -155,7 +155,7 @@ from enrichmcp import EnrichMCP, EnrichModel, Relationship
 from pydantic import Field
 
 app = EnrichMCP(
-    title="Task Management API", description="Simple task tracking system for AI agents"
+    title="Task Management API", instructions="Simple task tracking system for AI agents"
 )
 
 
@@ -332,7 +332,7 @@ A recipe API demonstrating many-to-many style relationships:
 from enrichmcp import EnrichMCP, EnrichModel, Relationship
 from pydantic import Field
 
-app = EnrichMCP(title="Recipe API", description="A collection of recipes with ingredients")
+app = EnrichMCP(title="Recipe API", instructions="A collection of recipes with ingredients")
 
 
 @app.entity

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ from enrichmcp import EnrichMCP, EnrichModel, Relationship
 from pydantic import Field
 
 # Create the application
-app = EnrichMCP(title="Book Catalog API", description="A simple book catalog for AI agents")
+app = EnrichMCP(title="Book Catalog API", instructions="A simple book catalog for AI agents")
 
 
 # Define entities
@@ -254,7 +254,7 @@ class Product(Base):
 
 
 lifespan = sqlalchemy_lifespan(Base, engine, cleanup_db_file=True)
-app = EnrichMCP("My ORM API", lifespan=lifespan)
+app = EnrichMCP("My ORM API", instructions="ORM API", lifespan=lifespan)
 include_sqlalchemy_models(app, Base)
 app.run()
 ```

--- a/docs/pagination.md
+++ b/docs/pagination.md
@@ -8,7 +8,7 @@ EnrichMCP provides comprehensive pagination support for both page-based and curs
 from enrichmcp import EnrichMCP, EnrichModel, PageResult, CursorResult
 from pydantic import Field
 
-app = EnrichMCP(title="My API", description="API with pagination")
+app = EnrichMCP(title="My API", instructions="API with pagination")
 
 
 @app.entity

--- a/examples/basic_memory/app.py
+++ b/examples/basic_memory/app.py
@@ -23,7 +23,7 @@ from enrichmcp import EnrichMCP
 store = FileMemoryStore(Path(__file__).parent / "data")
 project = MemoryProject("demo", store)
 
-app = EnrichMCP(title="Basic Memory API", description="Manage simple notes")
+app = EnrichMCP(title="Basic Memory API", instructions="Manage simple notes")
 
 
 @app.entity

--- a/examples/caching/app.py
+++ b/examples/caching/app.py
@@ -5,7 +5,7 @@ import random
 
 from enrichmcp import EnrichMCP
 
-app = EnrichMCP("Caching API", description="Demo of request caching")
+app = EnrichMCP("Caching API", instructions="Demo of request caching")
 
 
 @app.retrieve

--- a/examples/hello_world/app.py
+++ b/examples/hello_world/app.py
@@ -10,7 +10,7 @@ from enrichmcp import EnrichMCP
 
 def main():
     # Create the EnrichMCP application
-    app = EnrichMCP(title="Hello World API", description="A simple API that says hello!")
+    app = EnrichMCP(title="Hello World API", instructions="A simple API that says hello!")
 
     # Define a hello world resource
     @app.retrieve(description="Say hello to the world")

--- a/examples/hello_world_http/app.py
+++ b/examples/hello_world_http/app.py
@@ -4,7 +4,7 @@ from enrichmcp import EnrichMCP
 
 
 def main() -> None:
-    app = EnrichMCP(title="Hello HTTP API", description="A simple HTTP example")
+    app = EnrichMCP(title="Hello HTTP API", instructions="A simple HTTP example")
 
     @app.retrieve(description="Say hello over HTTP")
     async def hello_http() -> dict[str, str]:

--- a/examples/mutable_crud/app.py
+++ b/examples/mutable_crud/app.py
@@ -6,7 +6,7 @@ from enrichmcp import EnrichMCP, EnrichModel
 
 app = EnrichMCP(
     title="Customer CRUD API",
-    description="Demonstrates mutability and CRUD decorators",
+    instructions="Demonstrates mutability and CRUD decorators",
 )
 
 

--- a/examples/server_side_llm_travel_planner/app.py
+++ b/examples/server_side_llm_travel_planner/app.py
@@ -9,7 +9,7 @@ from enrichmcp import EnrichMCP, EnrichModel, prefer_fast_model
 
 app = EnrichMCP(
     title="Travel Planner",
-    description="Suggest destinations based on user preferences using LLM sampling",
+    instructions="Suggest destinations based on user preferences using LLM sampling",
 )
 
 

--- a/examples/shop_api/app.py
+++ b/examples/shop_api/app.py
@@ -15,7 +15,7 @@ from enrichmcp import EnrichMCP, EnrichModel, PageResult, Relationship
 # Create the application
 app = EnrichMCP(
     title="E-Commerce Shop API",
-    description=(
+    instructions=(
         "An e-commerce API with users, products, and orders including fraud detection patterns."
     ),
 )

--- a/examples/shop_api_gateway/app.py
+++ b/examples/shop_api_gateway/app.py
@@ -26,7 +26,7 @@ async def lifespan(app: EnrichMCP) -> AsyncIterator[dict[str, Any]]:
 
 app = EnrichMCP(
     title="Shop API Gateway",
-    description="EnrichMCP front-end for a FastAPI backend",
+    instructions="EnrichMCP front-end for a FastAPI backend",
     lifespan=lifespan,
 )
 

--- a/examples/shop_api_sqlite/app.py
+++ b/examples/shop_api_sqlite/app.py
@@ -322,7 +322,7 @@ async def lifespan(app: EnrichMCP) -> AsyncIterator[dict[str, Any]]:
 # Create the application with lifespan
 app = EnrichMCP(
     title="E-Commerce Shop API (SQLite)",
-    description="E-commerce API with SQLite database backend.",
+    instructions="E-commerce API with SQLite database backend.",
     lifespan=lifespan,
 )
 

--- a/examples/sqlalchemy_shop/app.py
+++ b/examples/sqlalchemy_shop/app.py
@@ -267,7 +267,7 @@ lifespan = sqlalchemy_lifespan(Base, engine, seed=seed_database, cleanup_db_file
 
 app = EnrichMCP(
     title="Shop API (SQLAlchemy)",
-    description="E-commerce shop API using SQLAlchemy models",
+    instructions="E-commerce shop API using SQLAlchemy models",
     lifespan=lifespan,
 )
 

--- a/tests/test_basic_memory_mcp_use.py
+++ b/tests/test_basic_memory_mcp_use.py
@@ -27,7 +27,7 @@ async def test_basic_memory_mcp_use(tmp_path: Path) -> None:
             store = FileMemoryStore(Path(__file__).parent / "data")
             project = MemoryProject("demo", store)
 
-            app = EnrichMCP(title="Test", description="Desc")
+            app = EnrichMCP(title="Test", instructions="Desc")
 
             @app.entity
             class Note(MemoryNote):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -13,7 +13,7 @@ from enrichmcp import (
 @pytest.mark.asyncio
 async def test_app_entity_decorator():
     """Test app.entity decorator."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.entity(description="Test entity")
     class TestEntity(EnrichModel):
@@ -28,7 +28,7 @@ async def test_app_entity_decorator():
 @pytest.mark.asyncio
 async def test_entity_decorator_without_parens():
     """Test app.entity decorator without parentheses."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.entity
     class TestEntityNoParens(EnrichModel):
@@ -47,7 +47,7 @@ async def test_entity_decorator_without_parens():
 @pytest.mark.asyncio
 async def test_entity_with_description():
     """Test app.entity decorator with description override."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.entity(description="Custom entity description")
     class UserWithDescription(EnrichModel):
@@ -67,7 +67,7 @@ async def test_entity_with_description():
 @pytest.mark.asyncio
 async def test_resource_decorator():
     """Test resource decorator."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.retrieve(description="Get user resource")
     async def get_user(*, id: int) -> dict:
@@ -83,7 +83,7 @@ async def test_resource_decorator():
 @pytest.mark.asyncio
 async def test_resource_decorator_without_parens():
     """Test resource decorator without parentheses."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.retrieve
     async def get_user_no_parens(*, id: int) -> dict:
@@ -100,7 +100,7 @@ async def test_resource_decorator_without_parens():
 @pytest.mark.asyncio
 async def test_resource_decorator_empty_parens():
     """Test resource decorator with empty parentheses."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.retrieve()
     async def get_user_empty_parens(*, id: int) -> dict:
@@ -117,7 +117,7 @@ async def test_resource_decorator_empty_parens():
 @pytest.mark.asyncio
 async def test_resource_with_description():
     """Test resource decorator with description override."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.retrieve(name="custom_name", description="Custom resource description")
     async def get_data() -> dict:
@@ -135,7 +135,7 @@ async def test_resource_with_description():
 @pytest.mark.asyncio
 async def test_resource_without_description_fails():
     """Test that resource decorator fails without description."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     with pytest.raises(ValueError, match="must have a description"):
 
@@ -148,7 +148,7 @@ async def test_resource_without_description_fails():
 @pytest.mark.asyncio
 async def test_entity_without_description_fails():
     """Test that entity decorator fails without description."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     with pytest.raises(ValueError, match="must have a description"):
 
@@ -161,7 +161,7 @@ async def test_entity_without_description_fails():
 def test_get_context_returns_enrich_context():
     """app.get_context should return an EnrichContext"""
 
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
     ctx = app.get_context()
 
     assert isinstance(ctx, EnrichContext)
@@ -172,7 +172,7 @@ def test_get_context_returns_enrich_context():
 
 
 def test_get_context_propagates_errors():
-    app = EnrichMCP("Test API", description="desc")
+    app = EnrichMCP("Test API", instructions="desc")
 
     with (
         patch.object(app.mcp, "get_context", side_effect=RuntimeError("boom")),
@@ -185,7 +185,7 @@ def test_get_context_propagates_errors():
 async def test_tool_wrapper():
     """app.tool should call FastMCP.tool without extra behavior."""
 
-    app = EnrichMCP("Test API", description="desc")
+    app = EnrichMCP("Test API", instructions="desc")
 
     with patch.object(app.mcp, "tool", wraps=app.mcp.tool) as mock_tool:
 
@@ -203,7 +203,7 @@ async def test_tool_wrapper():
 async def test_tool_wrapper_defaults():
     """Defaults should use function name and docstring."""
 
-    app = EnrichMCP("Test API", description="desc")
+    app = EnrichMCP("Test API", instructions="desc")
 
     @app.tool()
     async def default_tool(x: int) -> int:

--- a/tests/test_describe.py
+++ b/tests/test_describe.py
@@ -12,7 +12,7 @@ from enrichmcp import (
 
 def test_field_requires_description():
     """Test that entity fields require descriptions."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Should work with field descriptions
     @app.entity(description="User entity")
@@ -36,7 +36,7 @@ def test_field_requires_description():
 
 def test_describe_method():
     """Test the describe method of EnrichModel."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.entity(description="User entity for testing")
     class User(EnrichModel):
@@ -66,7 +66,7 @@ def test_describe_method():
 
 def test_describe_method_with_complex_types():
     """Test the describe method with complex field types."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     @app.entity(description="Blog post entity")
     class Post(EnrichModel):

--- a/tests/test_descriptions.py
+++ b/tests/test_descriptions.py
@@ -9,7 +9,7 @@ from enrichmcp import (
 
 def test_entity_requires_description_via_parameter():
     """Test that entity requires a description via parameter."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Should work with a description
     @app.entity(description="Test entity description")
@@ -23,7 +23,7 @@ def test_entity_requires_description_via_parameter():
 
 def test_entity_accepts_class_docstring():
     """Test that entity accepts a class docstring as description."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Should work with a class docstring
     @app.entity
@@ -39,7 +39,7 @@ def test_entity_accepts_class_docstring():
 
 def test_entity_raises_error_without_description():
     """Test that entity raises error without description."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Should fail without a description
     with pytest.raises(ValueError) as exc_info:
@@ -55,7 +55,7 @@ def test_entity_raises_error_without_description():
 
 def test_resource_requires_description_via_parameter():
     """Test that resource requires a description via parameter."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Should work with a description
     @app.retrieve(description="Test resource description")
@@ -67,7 +67,7 @@ def test_resource_requires_description_via_parameter():
 
 def test_resource_accepts_function_docstring():
     """Test that resource accepts a function docstring as description."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Should work with a function docstring
     @app.retrieve()
@@ -80,7 +80,7 @@ def test_resource_accepts_function_docstring():
 
 def test_resource_raises_error_without_description():
     """Test that resource raises error without description."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Should fail without a description
     with pytest.raises(ValueError) as exc_info:
@@ -95,7 +95,7 @@ def test_resource_raises_error_without_description():
 
 def test_resource_with_custom_name_and_description():
     """Test resource with custom name and description."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Should work with custom name and description
     @app.retrieve(name="custom_name", description="Custom resource description")

--- a/tests/test_enrichparameter.py
+++ b/tests/test_enrichparameter.py
@@ -7,7 +7,7 @@ from enrichmcp import EnrichContext, EnrichMCP, EnrichParameter
 
 @pytest.mark.asyncio
 async def test_enrichparameter_hints_appended():
-    app = EnrichMCP("Test", description="desc")
+    app = EnrichMCP("Test", instructions="desc")
     with patch.object(app.mcp, "tool", wraps=app.mcp.tool) as mock_tool:
 
         @app.retrieve(description="Base desc")

--- a/tests/test_explore_data_model.py
+++ b/tests/test_explore_data_model.py
@@ -6,7 +6,7 @@ from enrichmcp import DataModelSummary, EnrichMCP, EnrichModel
 
 @pytest.mark.asyncio
 async def test_explore_data_model_returns_summary() -> None:
-    app = EnrichMCP("My API", description="Demo server")
+    app = EnrichMCP("My API", instructions="Demo server")
 
     @app.entity(description="Test entity")
     class Item(EnrichModel):

--- a/tests/test_model_description.py
+++ b/tests/test_model_description.py
@@ -12,7 +12,7 @@ from enrichmcp import (
 
 def test_describe_model_empty():
     """Test describe_model with no entities."""
-    app = EnrichMCP("Test API", description="Test API description")
+    app = EnrichMCP("Test API", instructions="Test API description")
 
     # Get the structured model description
     model = app.describe_model_struct()
@@ -26,7 +26,7 @@ def test_describe_model_empty():
 
 def test_describe_model_with_entities():
     """Test describe_model with multiple entities and relationships."""
-    app = EnrichMCP("Social Network", description="A social network data model")
+    app = EnrichMCP("Social Network", instructions="A social network data model")
 
     # Define some entities
     @app.entity(description="User entity for the social network")
@@ -85,7 +85,7 @@ def test_describe_model_with_entities():
 
 def test_describe_model_with_complex_types():
     """Test describe_model with complex field types."""
-    app = EnrichMCP("Content Management", description="A CMS data model")
+    app = EnrichMCP("Content Management", instructions="A CMS data model")
 
     # Define an entity with complex types
     @app.entity(description="Article entity with complex field types")
@@ -125,7 +125,7 @@ def test_describe_model_with_complex_types():
 
 def test_describe_model_with_literal_type():
     """Test describe_model with Literal field types."""
-    app = EnrichMCP("Enum API", description="A model with Literal fields")
+    app = EnrichMCP("Enum API", instructions="A model with Literal fields")
 
     @app.entity(description="Entity using Literal")
     class Item(EnrichModel):

--- a/tests/test_mutability.py
+++ b/tests/test_mutability.py
@@ -6,7 +6,7 @@ from enrichmcp import EnrichMCP, EnrichModel
 
 @pytest.mark.asyncio
 async def test_patch_model_generation_and_mutable_fields():
-    app = EnrichMCP("Test API", description="desc")
+    app = EnrichMCP("Test API", instructions="desc")
 
     @app.entity
     class Customer(EnrichModel):
@@ -25,7 +25,7 @@ async def test_patch_model_generation_and_mutable_fields():
 
 @pytest.mark.asyncio
 async def test_crud_decorators_register_resources():
-    app = EnrichMCP("API", description="desc")
+    app = EnrichMCP("API", instructions="desc")
 
     @app.entity
     class Item(EnrichModel):

--- a/tests/test_pagination_integration.py
+++ b/tests/test_pagination_integration.py
@@ -21,7 +21,7 @@ from enrichmcp import (
 @pytest.fixture
 def app():
     """Create test app with entities."""
-    app = EnrichMCP(title="Test API", description="Test API")
+    app = EnrichMCP(title="Test API", instructions="Test API")
 
     # Define entities with forward references like in SQLite example
     @app.entity

--- a/tests/test_relationship_edge_cases.py
+++ b/tests/test_relationship_edge_cases.py
@@ -81,7 +81,7 @@ def test_relationship_is_compatible_type():
 
 def test_resolver_with_missing_types():
     """Test resolvers with missing type annotations."""
-    app = EnrichMCP(title="Test API", description="Test API for type validation")
+    app = EnrichMCP(title="Test API", instructions="Test API for type validation")
 
     @app.entity
     class Item(EnrichModel):
@@ -123,7 +123,7 @@ def test_resolver_with_missing_types():
 
 def test_resolver_with_string_types():
     """Test resolvers with string type annotations."""
-    app = EnrichMCP(title="Test API", description="Test API for string types")
+    app = EnrichMCP(title="Test API", instructions="Test API for string types")
 
     # Define entity with string type annotation
     @app.entity
@@ -151,7 +151,7 @@ def test_resolver_with_string_types():
 
 def test_resolver_with_union_type():
     """Test resolvers with Union type annotations."""
-    app = EnrichMCP(title="Test API", description="Test API for Union types")
+    app = EnrichMCP(title="Test API", instructions="Test API for Union types")
 
     @app.entity
     class Item(EnrichModel):

--- a/tests/test_relationship_resolvers.py
+++ b/tests/test_relationship_resolvers.py
@@ -13,7 +13,7 @@ from enrichmcp.relationship import Relationship
 def test_relationship_resolver_type_validation():
     """Test that relationship resolver type validation works correctly."""
 
-    app = EnrichMCP(title="Test API", description="Test API for type validation")
+    app = EnrichMCP(title="Test API", instructions="Test API for type validation")
 
     @app.entity
     class Item(EnrichModel):
@@ -62,7 +62,7 @@ def test_relationship_resolver_type_validation():
 def test_unresolved_relationship_validation():
     """Test that app.run() fails if a relationship is missing a resolver."""
 
-    app = EnrichMCP(title="Test API", description="Test API for relationship validation")
+    app = EnrichMCP(title="Test API", instructions="Test API for relationship validation")
 
     @app.entity
     class Item(EnrichModel):

--- a/tests/test_tooldef.py
+++ b/tests/test_tooldef.py
@@ -8,7 +8,7 @@ from enrichmcp import EnrichMCP, EnrichModel, Relationship
 
 @pytest.mark.asyncio
 async def test_tool_description_prefixes() -> None:
-    app = EnrichMCP("My API", description="desc")
+    app = EnrichMCP("My API", instructions="desc")
 
     with patch.object(app.mcp, "tool", wraps=app.mcp.tool) as mock_tool:
 


### PR DESCRIPTION
## Summary
- forward `description` to FastMCP using new `instructions` parameter
- rename `EnrichMCP`'s `description` argument to `instructions`
- update documentation, examples, and tests for `instructions` parameter

## Testing
- `pre-commit run --files $(git diff --name-only)`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68942a36950c832aae9c2ad7e7d0fe5f