### PR TITLE
refactor: persist cache across tool calls

### DIFF
--- a/tests/test_enrichparameter.py
+++ b/tests/test_enrichparameter.py
@@ -2,7 +2,7 @@ from unittest.mock import patch
 
 import pytest
 
-from enrichmcp import EnrichContext, EnrichMCP, EnrichParameter
+from enrichmcp import EnrichMCP, EnrichParameter
 
 
 @pytest.mark.asyncio
@@ -12,7 +12,6 @@ async def test_enrichparameter_hints_appended():
 
         @app.retrieve(description="Base desc")
         async def my_resource(
-            ctx: EnrichContext,
             name: str = EnrichParameter(description="user name", examples=["bob"]),
         ) -> dict:
             return {}
@@ -22,4 +21,3 @@ async def test_enrichparameter_hints_appended():
     assert "name - str" in desc
     assert "user name" in desc
     assert "examples: bob" in desc
-    assert "ctx" not in desc


### PR DESCRIPTION
## Summary
- maintain a shared ContextCache on the app so request-level caches survive across tool invocations
- remove automatic `EnrichContext` parameter injection; tools call `app.get_context()` when needed
- update tests to reflect manual context retrieval and verify cache reuse

## Testing
- `pre-commit run --files src/enrichmcp/app.py tests/test_cache.py tests/test_enrichparameter.py`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689cba56ad98832a9b7b342f5012660d